### PR TITLE
feat: add reusable marketing and layout UI components

### DIFF
--- a/apps/web/components/Badge.tsx
+++ b/apps/web/components/Badge.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import React from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export type BadgeVariant = 'solid' | 'outline' | 'soft'
+export type BadgeColor = 'neutral' | 'primary' | 'success' | 'warning' | 'danger' | 'info'
+export type BadgeSize = 'sm' | 'md' | 'lg'
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant
+  color?: BadgeColor
+  size?: BadgeSize
+  icon?: LucideIcon
+  iconPosition?: 'left' | 'right'
+  rounded?: 'default' | 'full'
+  children: React.ReactNode
+}
+
+const badgeSizeStyles: Record<BadgeSize, string> = {
+  sm: 'px-2 py-0.5 text-xs gap-1',
+  md: 'px-2.5 py-1 text-xs sm:text-sm gap-1.5',
+  lg: 'px-3 py-1.5 text-sm gap-2',
+}
+
+const badgeIconSizeStyles: Record<BadgeSize, string> = {
+  sm: 'h-3 w-3',
+  md: 'h-3.5 w-3.5',
+  lg: 'h-4 w-4',
+}
+
+const badgeColorStyles: Record<BadgeVariant, Record<BadgeColor, string>> = {
+  solid: {
+    neutral: 'bg-gray-900 text-white dark:bg-neutral-100 dark:text-neutral-900',
+    primary: 'bg-primary text-white',
+    success: 'bg-green-600 text-white',
+    warning: 'bg-amber-500 text-amber-950',
+    danger: 'bg-red-600 text-white',
+    info: 'bg-sky-600 text-white',
+  },
+  outline: {
+    neutral: 'border border-gray-300 text-gray-700 dark:border-neutral-600 dark:text-neutral-200',
+    primary: 'border border-primary/40 text-primary bg-primary/5',
+    success: 'border border-green-300 text-green-700 dark:border-green-700 dark:text-green-300',
+    warning: 'border border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-300',
+    danger: 'border border-red-300 text-red-700 dark:border-red-700 dark:text-red-300',
+    info: 'border border-sky-300 text-sky-700 dark:border-sky-700 dark:text-sky-300',
+  },
+  soft: {
+    neutral: 'bg-gray-100 text-gray-700 dark:bg-neutral-800 dark:text-neutral-200',
+    primary: 'bg-primary/10 text-primary',
+    success: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+    warning: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
+    danger: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+    info: 'bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300',
+  },
+}
+
+export function Badge({
+  variant = 'soft',
+  color = 'neutral',
+  size = 'md',
+  icon: Icon,
+  iconPosition = 'left',
+  rounded = 'full',
+  className,
+  children,
+  ...props
+}: BadgeProps) {
+  const iconNode = Icon ? <Icon className={cn('shrink-0', badgeIconSizeStyles[size])} aria-hidden="true" /> : null
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center font-medium leading-none',
+        rounded === 'full' ? 'rounded-full' : 'rounded-md',
+        badgeSizeStyles[size],
+        badgeColorStyles[variant][color],
+        className
+      )}
+      {...props}
+    >
+      {iconPosition === 'left' && iconNode}
+      <span>{children}</span>
+      {iconPosition === 'right' && iconNode}
+    </span>
+  )
+}
+

--- a/apps/web/components/Banner.tsx
+++ b/apps/web/components/Banner.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import React, { useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { X } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { Button, type ButtonVariant } from './Button'
+import { cn } from '@/lib/utils'
+
+export type BannerVariant = 'default' | 'primary' | 'success' | 'warning' | 'danger'
+
+export interface BannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: React.ReactNode
+  description?: React.ReactNode
+  eyebrow?: React.ReactNode
+  icon?: LucideIcon
+  ctaLabel?: string
+  ctaHref?: string
+  onCtaClick?: () => void
+  ctaVariant?: ButtonVariant
+  secondaryAction?: React.ReactNode
+  variant?: BannerVariant
+  backgroundImageSrc?: string
+  backgroundImageAlt?: string
+  dismissible?: boolean
+  onDismiss?: () => void
+}
+
+const bannerVariantStyles: Record<BannerVariant, string> = {
+  default:
+    'border-gray-200 bg-white text-gray-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white',
+  primary:
+    'border-primary/20 bg-gradient-to-r from-primary/10 via-primary/5 to-transparent text-gray-900 dark:text-white',
+  success:
+    'border-green-200 bg-gradient-to-r from-green-50 to-white text-gray-900 dark:border-green-800 dark:from-green-950/20 dark:to-neutral-900 dark:text-white',
+  warning:
+    'border-amber-200 bg-gradient-to-r from-amber-50 to-white text-gray-900 dark:border-amber-800 dark:from-amber-950/20 dark:to-neutral-900 dark:text-white',
+  danger:
+    'border-red-200 bg-gradient-to-r from-red-50 to-white text-gray-900 dark:border-red-800 dark:from-red-950/20 dark:to-neutral-900 dark:text-white',
+}
+
+function bannerCtaLinkClasses(variant: ButtonVariant) {
+  const base =
+    'inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 active:scale-[0.98]'
+
+  const variants: Record<ButtonVariant, string> = {
+    primary: 'bg-primary text-white hover:bg-primary/90 focus:ring-primary',
+    secondary:
+      'border border-gray-300 bg-white text-gray-900 hover:bg-gray-50 focus:ring-gray-400 dark:border-neutral-600 dark:bg-neutral-800 dark:text-white dark:hover:bg-neutral-700',
+    tertiary: 'bg-transparent text-inherit hover:bg-black/5 focus:ring-gray-400 dark:hover:bg-white/10',
+  }
+
+  return cn(base, variants[variant])
+}
+
+export function Banner({
+  title,
+  description,
+  eyebrow,
+  icon: Icon,
+  ctaLabel,
+  ctaHref,
+  onCtaClick,
+  ctaVariant = 'primary',
+  secondaryAction,
+  variant = 'default',
+  backgroundImageSrc,
+  backgroundImageAlt = '',
+  dismissible = false,
+  onDismiss,
+  className,
+  children,
+  ...props
+}: BannerProps) {
+  const [isVisible, setIsVisible] = useState(true)
+
+  if (!isVisible) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-2xl border shadow-sm',
+        'transition-all duration-200',
+        bannerVariantStyles[variant],
+        className
+      )}
+      {...props}
+    >
+      {backgroundImageSrc ? (
+        <>
+          <div className="absolute inset-0 opacity-20" aria-hidden="true">
+            <Image src={backgroundImageSrc} alt={backgroundImageAlt} fill sizes="100vw" className="object-cover" />
+          </div>
+          <div className="absolute inset-0 bg-gradient-to-r from-white/95 via-white/90 to-white/80 dark:from-neutral-900/95 dark:via-neutral-900/90 dark:to-neutral-900/75" aria-hidden="true" />
+        </>
+      ) : null}
+
+      <div className="relative px-4 py-4 sm:px-6 sm:py-5">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-start gap-3">
+            {Icon ? (
+              <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/80 text-primary shadow-sm ring-1 ring-black/5 dark:bg-neutral-800 dark:text-primary">
+                <Icon className="h-5 w-5" aria-hidden="true" />
+              </div>
+            ) : null}
+
+            <div className="min-w-0 space-y-1">
+              {eyebrow ? (
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-gray-500 dark:text-neutral-400">
+                  {eyebrow}
+                </p>
+              ) : null}
+              <p className="text-base font-semibold leading-6 sm:text-lg">{title}</p>
+              {description ? (
+                <p className="text-sm leading-6 text-gray-600 dark:text-neutral-300">{description}</p>
+              ) : null}
+              {children}
+            </div>
+          </div>
+
+          <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+            {ctaLabel && ctaHref ? (
+              <Link href={ctaHref} className={bannerCtaLinkClasses(ctaVariant)}>
+                {ctaLabel}
+              </Link>
+            ) : null}
+
+            {ctaLabel && !ctaHref ? (
+              <Button size="small" variant={ctaVariant} onClick={onCtaClick}>
+                {ctaLabel}
+              </Button>
+            ) : null}
+
+            {secondaryAction}
+
+            {dismissible ? (
+              <button
+                type="button"
+                aria-label="Dismiss banner"
+                onClick={() => {
+                  setIsVisible(false)
+                  onDismiss?.()
+                }}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-black/5 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary dark:text-neutral-300 dark:hover:bg-white/10 dark:hover:text-white"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -1,0 +1,271 @@
+'use client'
+
+import React, { useState } from 'react'
+import Link from 'next/link'
+import { Facebook, Github, Instagram, Linkedin, Mail, Send, Twitter } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { Button } from './Button'
+import { FooterSection, type FooterLinkItem } from './FooterSection'
+import { cn } from '@/lib/utils'
+
+export interface FooterLinkGroup {
+  title: string
+  links: FooterLinkItem[]
+}
+
+export interface FooterSocialLink extends FooterLinkItem {
+  icon: LucideIcon
+}
+
+type NewsletterState = 'idle' | 'submitting' | 'success' | 'error'
+
+export interface FooterProps extends React.HTMLAttributes<HTMLElement> {
+  companyName?: string
+  companyDescription?: string
+  logo?: React.ReactNode
+  navigationSections?: FooterLinkGroup[]
+  socialLinks?: FooterSocialLink[]
+  legalLinks?: FooterLinkItem[]
+  showNewsletter?: boolean
+  newsletterTitle?: string
+  newsletterDescription?: string
+  newsletterPlaceholder?: string
+  newsletterAction?: string
+  newsletterMethod?: 'get' | 'post'
+  onNewsletterSubmit?: (email: string) => void | Promise<void>
+  sticky?: boolean
+  copyrightText?: string
+}
+
+const defaultNavigationSections: FooterLinkGroup[] = [
+  {
+    title: 'Product',
+    links: [
+      { label: 'Browse Listings', href: '/browse' },
+      { label: 'Payments', href: '/payments/history' },
+      { label: 'Dashboard', href: '/dashboard' },
+    ],
+  },
+  {
+    title: 'Company',
+    links: [
+      { label: 'About', href: '/' },
+      { label: 'Contact', href: '/message/1' },
+      { label: 'Privacy', href: '/privacy' },
+    ],
+  },
+]
+
+const defaultSocialLinks: FooterSocialLink[] = [
+  { label: 'X / Twitter', href: 'https://twitter.com', external: true, icon: Twitter },
+  { label: 'LinkedIn', href: 'https://linkedin.com', external: true, icon: Linkedin },
+  { label: 'GitHub', href: 'https://github.com', external: true, icon: Github },
+  { label: 'Instagram', href: 'https://instagram.com', external: true, icon: Instagram },
+  { label: 'Facebook', href: 'https://facebook.com', external: true, icon: Facebook },
+]
+
+const defaultLegalLinks: FooterLinkItem[] = [
+  { label: 'Privacy Policy', href: '/privacy' },
+  { label: 'Terms', href: '/#terms' },
+  { label: 'Cookies', href: '/#cookies' },
+]
+
+export function Footer({
+  companyName = 'PayEasy',
+  companyDescription = 'Secure payments and renter workflows built for modern housing experiences.',
+  logo,
+  navigationSections = defaultNavigationSections,
+  socialLinks = defaultSocialLinks,
+  legalLinks = defaultLegalLinks,
+  showNewsletter = true,
+  newsletterTitle = 'Stay in the loop',
+  newsletterDescription = 'Get product updates, launch news, and payment tips in your inbox.',
+  newsletterPlaceholder = 'Enter your email',
+  newsletterAction,
+  newsletterMethod = 'post',
+  onNewsletterSubmit,
+  sticky = false,
+  copyrightText,
+  className,
+  ...props
+}: FooterProps) {
+  const [email, setEmail] = useState('')
+  const [newsletterState, setNewsletterState] = useState<NewsletterState>('idle')
+  const [newsletterMessage, setNewsletterMessage] = useState<string | null>(null)
+
+  const shouldInterceptSubmit = Boolean(onNewsletterSubmit) || !newsletterAction
+
+  const handleNewsletterSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    if (shouldInterceptSubmit) {
+      event.preventDefault()
+    }
+
+    if (!shouldInterceptSubmit) {
+      return
+    }
+
+    const normalized = email.trim()
+    if (!normalized) {
+      setNewsletterState('error')
+      setNewsletterMessage('Please enter a valid email address.')
+      return
+    }
+
+    setNewsletterState('submitting')
+    setNewsletterMessage(null)
+
+    try {
+      if (onNewsletterSubmit) {
+        await onNewsletterSubmit(normalized)
+      }
+
+      setNewsletterState('success')
+      setNewsletterMessage('Thanks for subscribing.')
+      setEmail('')
+    } catch (error) {
+      setNewsletterState('error')
+      setNewsletterMessage(error instanceof Error ? error.message : 'Subscription failed. Try again.')
+    }
+  }
+
+  const year = new Date().getFullYear()
+
+  return (
+    <footer
+      className={cn(
+        'border-t border-gray-200 bg-white text-gray-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white',
+        sticky && 'mt-auto',
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 sm:py-12 lg:px-8">
+        <div className="grid gap-8 lg:grid-cols-12">
+          <div className="space-y-4 lg:col-span-4">
+            <div className="flex items-center gap-3">
+              {logo ? (
+                <div className="shrink-0">{logo}</div>
+              ) : (
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <Send className="h-5 w-5" aria-hidden="true" />
+                </div>
+              )}
+              <div>
+                <p className="text-base font-semibold">{companyName}</p>
+                <p className="text-sm text-gray-600 dark:text-neutral-400">Fast, secure, reliable</p>
+              </div>
+            </div>
+
+            <p className="max-w-md text-sm leading-6 text-gray-600 dark:text-neutral-300">{companyDescription}</p>
+
+            <div className="flex flex-wrap items-center gap-2">
+              {socialLinks.map((social) => {
+                const Icon = social.icon
+                return (
+                  <Link
+                    key={`${social.href}-${social.label}`}
+                    href={social.href}
+                    target={social.external ? '_blank' : undefined}
+                    rel={social.external ? 'noopener noreferrer' : undefined}
+                    aria-label={social.ariaLabel ?? social.label}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 text-gray-600 transition-colors hover:border-primary/40 hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/40 dark:border-neutral-700 dark:text-neutral-300 dark:hover:border-primary/40"
+                  >
+                    <Icon className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="grid gap-8 sm:grid-cols-2 lg:col-span-4">
+            {navigationSections.map((section) => (
+              <FooterSection key={section.title} title={section.title} links={section.links} />
+            ))}
+          </div>
+
+          {showNewsletter ? (
+            <FooterSection
+              title={newsletterTitle}
+              description={newsletterDescription}
+              className="lg:col-span-4"
+            >
+              <form
+                action={newsletterAction}
+                method={newsletterMethod}
+                onSubmit={handleNewsletterSubmit}
+                className="space-y-3"
+              >
+                <label htmlFor="footer-newsletter-email" className="sr-only">
+                  Email address
+                </label>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <div className="relative flex-1">
+                    <Mail className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" aria-hidden="true" />
+                    <input
+                      id="footer-newsletter-email"
+                      name="email"
+                      type="email"
+                      required
+                      autoComplete="email"
+                      inputMode="email"
+                      value={email}
+                      onChange={(event) => {
+                        setEmail(event.target.value)
+                        if (newsletterState !== 'idle') {
+                          setNewsletterState('idle')
+                          setNewsletterMessage(null)
+                        }
+                      }}
+                      placeholder={newsletterPlaceholder}
+                      className="h-11 w-full rounded-lg border border-gray-300 bg-white pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-400 shadow-sm outline-none ring-0 transition focus:border-primary focus:ring-2 focus:ring-primary/30 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white dark:placeholder:text-neutral-500"
+                    />
+                  </div>
+                  <Button
+                    type="submit"
+                    size="small"
+                    isLoading={newsletterState === 'submitting'}
+                    className="h-11 min-w-[120px]"
+                  >
+                    Subscribe
+                  </Button>
+                </div>
+
+                {newsletterMessage ? (
+                  <p
+                    role={newsletterState === 'error' ? 'alert' : 'status'}
+                    className={cn(
+                      'text-sm',
+                      newsletterState === 'error'
+                        ? 'text-red-600 dark:text-red-400'
+                        : 'text-green-700 dark:text-green-400'
+                    )}
+                  >
+                    {newsletterMessage}
+                  </p>
+                ) : null}
+              </form>
+            </FooterSection>
+          ) : null}
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 border-t border-gray-200 pt-6 text-sm text-gray-600 dark:border-neutral-800 dark:text-neutral-400 sm:flex-row sm:items-center sm:justify-between">
+          <p>{copyrightText ?? `© ${year} ${companyName}. All rights reserved.`}</p>
+
+          <nav aria-label="Legal links" className="flex flex-wrap items-center gap-x-4 gap-y-2">
+            {legalLinks.map((link) => (
+              <Link
+                key={`${link.href}-${link.label}`}
+                href={link.href}
+                target={link.external ? '_blank' : undefined}
+                rel={link.external ? 'noopener noreferrer' : undefined}
+                className="transition-colors hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/apps/web/components/FooterSection.tsx
+++ b/apps/web/components/FooterSection.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+export interface FooterLinkItem {
+  label: string
+  href: string
+  external?: boolean
+  ariaLabel?: string
+}
+
+export interface FooterSectionProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: React.ReactNode
+  description?: React.ReactNode
+  links?: FooterLinkItem[]
+  listClassName?: string
+}
+
+export function FooterSection({
+  title,
+  description,
+  links = [],
+  className,
+  listClassName,
+  children,
+  ...props
+}: FooterSectionProps) {
+  return (
+    <div className={cn('space-y-3', className)} {...props}>
+      <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-gray-900 dark:text-white">{title}</h3>
+
+      {description ? <p className="text-sm leading-6 text-gray-600 dark:text-neutral-300">{description}</p> : null}
+
+      {links.length > 0 ? (
+        <ul className={cn('space-y-2', listClassName)}>
+          {links.map((link) => (
+            <li key={`${link.href}-${link.label}`}>
+              <Link
+                href={link.href}
+                aria-label={link.ariaLabel}
+                target={link.external ? '_blank' : undefined}
+                rel={link.external ? 'noopener noreferrer' : undefined}
+                className="text-sm text-gray-600 transition-colors hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/40 dark:text-neutral-300 dark:hover:text-primary"
+              >
+                {link.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {children}
+    </div>
+  )
+}
+

--- a/apps/web/components/Hero.tsx
+++ b/apps/web/components/Hero.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import React from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Button, type ButtonVariant } from './Button'
+import { cn } from '@/lib/utils'
+
+export type HeroHeight = 'sm' | 'md' | 'lg' | 'screen'
+export type HeroAlign = 'left' | 'center' | 'right'
+
+export interface HeroProps extends React.HTMLAttributes<HTMLElement> {
+  title: React.ReactNode
+  subtitle?: React.ReactNode
+  eyebrow?: React.ReactNode
+  ctaLabel?: string
+  ctaHref?: string
+  onCtaClick?: () => void
+  ctaVariant?: ButtonVariant
+  ctaTarget?: React.AnchorHTMLAttributes<HTMLAnchorElement>['target']
+  ctaRel?: React.AnchorHTMLAttributes<HTMLAnchorElement>['rel']
+  secondaryAction?: React.ReactNode
+  backgroundImageSrc?: string
+  backgroundImageAlt?: string
+  backgroundVideoSrc?: string
+  backgroundVideoPoster?: string
+  backgroundVideoType?: string
+  overlayClassName?: string
+  contentClassName?: string
+  mediaClassName?: string
+  height?: HeroHeight
+  align?: HeroAlign
+  priorityImage?: boolean
+  videoAutoPlay?: boolean
+  videoLoop?: boolean
+  videoMuted?: boolean
+  videoControls?: boolean
+}
+
+const heroHeightStyles: Record<HeroHeight, string> = {
+  sm: 'min-h-[22rem] sm:min-h-[26rem]',
+  md: 'min-h-[26rem] sm:min-h-[32rem]',
+  lg: 'min-h-[32rem] sm:min-h-[38rem]',
+  screen: 'min-h-[70vh] sm:min-h-[80vh]',
+}
+
+const heroAlignmentStyles: Record<HeroAlign, string> = {
+  left: 'text-left items-start',
+  center: 'text-center items-center',
+  right: 'text-right items-end',
+}
+
+function ctaLinkClasses(variant: ButtonVariant) {
+  const base =
+    'inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 py-2 text-base font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 active:scale-[0.98]'
+
+  const variants: Record<ButtonVariant, string> = {
+    primary:
+      'bg-primary text-white shadow-sm hover:bg-primary/90 hover:shadow-md active:bg-primary/80 focus:ring-primary focus:ring-offset-white/30',
+    secondary:
+      'bg-white/90 text-gray-900 shadow-sm hover:bg-white hover:shadow-md focus:ring-white/60',
+    tertiary:
+      'border border-white/30 bg-white/5 text-white backdrop-blur-sm hover:bg-white/10 focus:ring-white/60',
+  }
+
+  return cn(base, variants[variant])
+}
+
+export function Hero({
+  title,
+  subtitle,
+  eyebrow,
+  ctaLabel,
+  ctaHref,
+  onCtaClick,
+  ctaVariant = 'primary',
+  ctaTarget,
+  ctaRel,
+  secondaryAction,
+  backgroundImageSrc,
+  backgroundImageAlt = '',
+  backgroundVideoSrc,
+  backgroundVideoPoster,
+  backgroundVideoType = 'video/mp4',
+  overlayClassName,
+  contentClassName,
+  mediaClassName,
+  height = 'lg',
+  align = 'left',
+  priorityImage = false,
+  videoAutoPlay = true,
+  videoLoop = true,
+  videoMuted = true,
+  videoControls = false,
+  className,
+  children,
+  ...props
+}: HeroProps) {
+  const showMedia = Boolean(backgroundImageSrc || backgroundVideoSrc)
+
+  return (
+    <section
+      className={cn(
+        'relative isolate overflow-hidden rounded-2xl border border-white/10 bg-slate-950 text-white shadow-2xl',
+        heroHeightStyles[height],
+        className
+      )}
+      {...props}
+    >
+      {showMedia ? (
+        <div className={cn('absolute inset-0 -z-20', mediaClassName)} aria-hidden="true">
+          {backgroundImageSrc ? (
+            <Image
+              src={backgroundImageSrc}
+              alt={backgroundImageAlt}
+              fill
+              priority={priorityImage}
+              sizes="100vw"
+              className="object-cover"
+            />
+          ) : null}
+
+          {backgroundVideoSrc ? (
+            <video
+              className="absolute inset-0 h-full w-full object-cover"
+              autoPlay={videoAutoPlay}
+              loop={videoLoop}
+              muted={videoMuted}
+              controls={videoControls}
+              playsInline
+              preload="metadata"
+              poster={backgroundVideoPoster}
+            >
+              <source src={backgroundVideoSrc} type={backgroundVideoType} />
+            </video>
+          ) : null}
+        </div>
+      ) : (
+        <div
+          className="absolute inset-0 -z-20 bg-[radial-gradient(circle_at_20%_20%,rgba(56,189,248,0.25),transparent_45%),radial-gradient(circle_at_80%_20%,rgba(99,102,241,0.18),transparent_50%),linear-gradient(180deg,#020617_0%,#0f172a_100%)]"
+          aria-hidden="true"
+        />
+      )}
+
+      <div
+        className={cn(
+          'absolute inset-0 -z-10 bg-gradient-to-br from-slate-950/85 via-slate-900/70 to-slate-900/90',
+          'sm:bg-gradient-to-r sm:from-slate-950/85 sm:via-slate-900/65 sm:to-slate-950/75',
+          overlayClassName
+        )}
+        aria-hidden="true"
+      />
+
+      <div className="relative flex h-full w-full items-stretch px-5 py-8 sm:px-8 sm:py-10 lg:px-12">
+        <div
+          className={cn(
+            'flex w-full max-w-3xl flex-col justify-center gap-5 sm:gap-6',
+            heroAlignmentStyles[align],
+            contentClassName
+          )}
+        >
+          {eyebrow ? (
+            <div className="inline-flex w-fit max-w-full items-center rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.14em] text-white/90 backdrop-blur-sm">
+              {eyebrow}
+            </div>
+          ) : null}
+
+          <div className="space-y-3 sm:space-y-4">
+            <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl lg:text-5xl xl:text-6xl">
+              {title}
+            </h1>
+            {subtitle ? (
+              <p className="max-w-2xl text-sm leading-6 text-slate-100/90 sm:text-base sm:leading-7 lg:text-lg">
+                {subtitle}
+              </p>
+            ) : null}
+          </div>
+
+          {(ctaLabel || secondaryAction) && (
+            <div
+              className={cn(
+                'flex flex-wrap items-center gap-3',
+                align === 'center' && 'justify-center',
+                align === 'right' && 'justify-end'
+              )}
+            >
+              {ctaLabel && ctaHref ? (
+                <Link href={ctaHref} target={ctaTarget} rel={ctaRel} className={ctaLinkClasses(ctaVariant)}>
+                  {ctaLabel}
+                </Link>
+              ) : null}
+
+              {ctaLabel && !ctaHref ? (
+                <Button variant={ctaVariant} onClick={onCtaClick} className="shadow-sm">
+                  {ctaLabel}
+                </Button>
+              ) : null}
+
+              {secondaryAction}
+            </div>
+          )}
+
+          {children ? <div>{children}</div> : null}
+        </div>
+      </div>
+    </section>
+  )
+}
+

--- a/apps/web/components/Tag.tsx
+++ b/apps/web/components/Tag.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export type TagVariant = 'solid' | 'outline' | 'soft'
+export type TagColor = 'neutral' | 'primary' | 'success' | 'warning' | 'danger' | 'info'
+export type TagSize = 'sm' | 'md' | 'lg'
+
+export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: TagVariant
+  color?: TagColor
+  size?: TagSize
+  icon?: LucideIcon
+  dismissible?: boolean
+  onDismiss?: () => void
+  dismissLabel?: string
+  dismissAfterMs?: number
+  animateDismiss?: boolean
+  children: React.ReactNode
+}
+
+const tagSizeStyles: Record<TagSize, string> = {
+  sm: 'px-2 py-1 text-xs gap-1',
+  md: 'px-2.5 py-1.5 text-sm gap-1.5',
+  lg: 'px-3 py-2 text-sm gap-2',
+}
+
+const tagIconSizeStyles: Record<TagSize, string> = {
+  sm: 'h-3 w-3',
+  md: 'h-3.5 w-3.5',
+  lg: 'h-4 w-4',
+}
+
+const tagDismissButtonSizeStyles: Record<TagSize, string> = {
+  sm: 'h-5 w-5',
+  md: 'h-6 w-6',
+  lg: 'h-7 w-7',
+}
+
+const tagColorStyles: Record<TagVariant, Record<TagColor, string>> = {
+  solid: {
+    neutral: 'bg-gray-900 text-white dark:bg-neutral-100 dark:text-neutral-900',
+    primary: 'bg-primary text-white',
+    success: 'bg-green-600 text-white',
+    warning: 'bg-amber-500 text-amber-950',
+    danger: 'bg-red-600 text-white',
+    info: 'bg-sky-600 text-white',
+  },
+  outline: {
+    neutral: 'bg-white text-gray-700 border border-gray-300 dark:bg-transparent dark:text-neutral-200 dark:border-neutral-600',
+    primary: 'bg-primary/5 text-primary border border-primary/30',
+    success: 'bg-green-50 text-green-700 border border-green-200 dark:bg-green-950/20 dark:text-green-300 dark:border-green-800',
+    warning: 'bg-amber-50 text-amber-700 border border-amber-200 dark:bg-amber-950/20 dark:text-amber-300 dark:border-amber-800',
+    danger: 'bg-red-50 text-red-700 border border-red-200 dark:bg-red-950/20 dark:text-red-300 dark:border-red-800',
+    info: 'bg-sky-50 text-sky-700 border border-sky-200 dark:bg-sky-950/20 dark:text-sky-300 dark:border-sky-800',
+  },
+  soft: {
+    neutral: 'bg-gray-100 text-gray-700 dark:bg-neutral-800 dark:text-neutral-200',
+    primary: 'bg-primary/10 text-primary',
+    success: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+    warning: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
+    danger: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+    info: 'bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300',
+  },
+}
+
+export function Tag({
+  variant = 'soft',
+  color = 'neutral',
+  size = 'md',
+  icon: Icon,
+  dismissible = false,
+  onDismiss,
+  dismissLabel = 'Remove tag',
+  dismissAfterMs = 180,
+  animateDismiss = true,
+  className,
+  children,
+  ...props
+}: TagProps) {
+  const [isVisible, setIsVisible] = useState(true)
+  const [isRemoving, setIsRemoving] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  if (!isVisible) {
+    return null
+  }
+
+  const handleDismiss = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    if (isRemoving) {
+      return
+    }
+
+    if (!animateDismiss) {
+      setIsVisible(false)
+      onDismiss?.()
+      return
+    }
+
+    setIsRemoving(true)
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(false)
+      onDismiss?.()
+    }, dismissAfterMs)
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex max-w-full items-center rounded-full font-medium',
+        'transition-all duration-200 motion-reduce:transition-none',
+        tagSizeStyles[size],
+        tagColorStyles[variant][color],
+        isRemoving && 'pointer-events-none scale-95 opacity-0 -translate-y-1',
+        className
+      )}
+      {...props}
+    >
+      {Icon ? <Icon className={cn('shrink-0', tagIconSizeStyles[size])} aria-hidden="true" /> : null}
+      <span className="truncate">{children}</span>
+      {dismissible ? (
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label={dismissLabel}
+          className={cn(
+            'ml-0.5 inline-flex shrink-0 items-center justify-center rounded-full',
+            'transition-colors hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-current/40',
+            'dark:hover:bg-white/10',
+            tagDismissButtonSizeStyles[size]
+          )}
+        >
+          <X className={tagIconSizeStyles[size]} aria-hidden="true" />
+        </button>
+      ) : null}
+    </span>
+  )
+}

--- a/apps/web/components/index.ts
+++ b/apps/web/components/index.ts
@@ -31,6 +31,22 @@ export {
 } from './Button'
 
 export {
+  Badge,
+  type BadgeProps,
+  type BadgeVariant,
+  type BadgeColor,
+  type BadgeSize,
+} from './Badge'
+
+export {
+  Tag,
+  type TagProps,
+  type TagVariant,
+  type TagColor,
+  type TagSize,
+} from './Tag'
+
+export {
   ButtonGroup,
   ButtonGroupItem,
   type ButtonGroupProps,
@@ -108,3 +124,51 @@ export {
   SingleImageGallery,
   ResponsiveGridGallery,
 } from './GalleryExamples'
+
+// Marketing Components
+export {
+  Hero,
+  type HeroProps,
+  type HeroHeight,
+  type HeroAlign,
+} from './Hero'
+
+export {
+  Banner,
+  type BannerProps,
+  type BannerVariant,
+} from './Banner'
+
+export {
+  Footer,
+  type FooterProps,
+  type FooterLinkGroup,
+  type FooterSocialLink,
+} from './Footer'
+
+export {
+  FooterSection,
+  type FooterSectionProps,
+  type FooterLinkItem,
+} from './FooterSection'
+
+// Layout Templates
+export {
+  Container,
+  Section,
+  TwoColumnLayout,
+  ThreeColumnLayout,
+  SidebarLayout,
+  GridLayout,
+  CONTAINER_WIDTH_CLASSES,
+  SECTION_SPACING_CLASSES,
+  type ContainerProps,
+  type SectionProps,
+  type ContainerWidth,
+  type SectionSpacing,
+  type LayoutGap,
+  type TwoColumnLayoutProps,
+  type ThreeColumnLayoutProps,
+  type SidebarLayoutProps,
+  type GridLayoutProps,
+} from './layouts'

--- a/apps/web/components/layouts/README.md
+++ b/apps/web/components/layouts/README.md
@@ -1,0 +1,59 @@
+# Layout Templates & Patterns
+
+Reusable layout primitives for consistent page structure across the app.
+
+## Included components
+
+- `Container`: standard width wrappers (`narrow`, `default`, `wide`, `full`)
+- `Section`: spacing presets with optional built-in container wrapper
+- `TwoColumnLayout`: responsive two-column templates
+- `ThreeColumnLayout`: responsive three-column templates
+- `SidebarLayout`: sidebar + main pattern with optional sticky sidebar
+- `GridLayout`: common card/grid templates
+
+## Width presets
+
+- `narrow`: readable content sections
+- `default`: forms and dashboards
+- `wide`: marketing pages and dense grids
+- `full`: edge-to-edge layouts
+
+## Spacing presets
+
+- `none`, `xs`, `sm`, `md`, `lg`, `xl`
+
+## Example usage
+
+```tsx
+import {
+  Section,
+  TwoColumnLayout,
+  SidebarLayout,
+  GridLayout,
+} from '@/components/layouts'
+
+<Section spacing="xl" containerWidth="wide">
+  <TwoColumnLayout
+    split="content-main"
+    left={<FiltersPanel />}
+    right={<ListingsGrid />}
+  />
+</Section>
+
+<Section spacing="lg">
+  <SidebarLayout sidebar={<ProfileNav />} stickySidebar>
+    <GridLayout template="cards-3">
+      <StatCard />
+      <StatCard />
+      <StatCard />
+    </GridLayout>
+  </SidebarLayout>
+</Section>
+```
+
+## Notes
+
+- All layouts are mobile-first and stack by default.
+- Use `gap` props to keep spacing consistent instead of ad-hoc utilities.
+- `Section` + `Container` should be the default outer page pattern.
+

--- a/apps/web/components/layouts/index.tsx
+++ b/apps/web/components/layouts/index.tsx
@@ -1,0 +1,267 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+
+export type ContainerWidth = 'narrow' | 'default' | 'wide' | 'full'
+export type SectionSpacing = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+export type LayoutGap = 'sm' | 'md' | 'lg' | 'xl'
+
+type SemanticContainerTag = 'div' | 'section' | 'main' | 'article' | 'header' | 'footer' | 'aside' | 'nav'
+
+export const CONTAINER_WIDTH_CLASSES: Record<ContainerWidth, string> = {
+  narrow: 'max-w-3xl',
+  default: 'max-w-5xl',
+  wide: 'max-w-7xl',
+  full: 'max-w-none',
+}
+
+export const SECTION_SPACING_CLASSES: Record<SectionSpacing, string> = {
+  none: 'py-0',
+  xs: 'py-4 sm:py-6',
+  sm: 'py-6 sm:py-8',
+  md: 'py-8 sm:py-12',
+  lg: 'py-12 sm:py-16',
+  xl: 'py-16 sm:py-24',
+}
+
+const GAP_CLASSES: Record<LayoutGap, string> = {
+  sm: 'gap-4',
+  md: 'gap-6',
+  lg: 'gap-8',
+  xl: 'gap-10',
+}
+
+export interface ContainerProps extends React.HTMLAttributes<HTMLElement> {
+  as?: SemanticContainerTag
+  width?: ContainerWidth
+  paddingX?: boolean
+}
+
+export function Container({
+  as = 'div',
+  width = 'wide',
+  paddingX = true,
+  className,
+  children,
+  ...props
+}: ContainerProps) {
+  const Component = as
+  return (
+    <Component
+      className={cn(
+        'mx-auto w-full',
+        CONTAINER_WIDTH_CLASSES[width],
+        paddingX && 'px-4 sm:px-6 lg:px-8',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  )
+}
+
+export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
+  as?: SemanticContainerTag
+  spacing?: SectionSpacing
+  containerWidth?: ContainerWidth
+  withContainer?: boolean
+  containerClassName?: string
+}
+
+export function Section({
+  as = 'section',
+  spacing = 'lg',
+  containerWidth = 'wide',
+  withContainer = true,
+  containerClassName,
+  className,
+  children,
+  ...props
+}: SectionProps) {
+  const Component = as
+
+  return (
+    <Component className={cn(SECTION_SPACING_CLASSES[spacing], className)} {...props}>
+      {withContainer ? (
+        <Container width={containerWidth} className={containerClassName}>
+          {children}
+        </Container>
+      ) : (
+        children
+      )}
+    </Component>
+  )
+}
+
+export type TwoColumnSplit = 'equal' | 'content-main' | 'main-content'
+
+export interface TwoColumnLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  left: React.ReactNode
+  right: React.ReactNode
+  split?: TwoColumnSplit
+  gap?: LayoutGap
+  reverseOnMobile?: boolean
+  align?: 'start' | 'center' | 'end'
+}
+
+const twoColumnSplitClasses: Record<TwoColumnSplit, string> = {
+  equal: 'lg:grid-cols-2',
+  'content-main': 'lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]',
+  'main-content': 'lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]',
+}
+
+const alignItemsClasses = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+} as const
+
+export function TwoColumnLayout({
+  left,
+  right,
+  split = 'equal',
+  gap = 'lg',
+  reverseOnMobile = false,
+  align = 'start',
+  className,
+  ...props
+}: TwoColumnLayoutProps) {
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-1',
+        twoColumnSplitClasses[split],
+        GAP_CLASSES[gap],
+        alignItemsClasses[align],
+        className
+      )}
+      {...props}
+    >
+      <div className={cn(reverseOnMobile && 'order-2 lg:order-1')}>{left}</div>
+      <div className={cn(reverseOnMobile && 'order-1 lg:order-2')}>{right}</div>
+    </div>
+  )
+}
+
+export type ThreeColumnDistribution = 'equal' | 'feature-first' | 'feature-middle'
+
+export interface ThreeColumnLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  first: React.ReactNode
+  second: React.ReactNode
+  third: React.ReactNode
+  distribution?: ThreeColumnDistribution
+  gap?: LayoutGap
+  align?: 'start' | 'center' | 'end'
+}
+
+const threeColumnDistributionClasses: Record<ThreeColumnDistribution, string> = {
+  equal: 'xl:grid-cols-3 md:grid-cols-2 grid-cols-1',
+  'feature-first': 'xl:grid-cols-[1.25fr_1fr_1fr] md:grid-cols-2 grid-cols-1',
+  'feature-middle': 'xl:grid-cols-[1fr_1.25fr_1fr] md:grid-cols-2 grid-cols-1',
+}
+
+export function ThreeColumnLayout({
+  first,
+  second,
+  third,
+  distribution = 'equal',
+  gap = 'lg',
+  align = 'start',
+  className,
+  ...props
+}: ThreeColumnLayoutProps) {
+  return (
+    <div
+      className={cn(
+        'grid',
+        threeColumnDistributionClasses[distribution],
+        GAP_CLASSES[gap],
+        alignItemsClasses[align],
+        className
+      )}
+      {...props}
+    >
+      <div>{first}</div>
+      <div>{second}</div>
+      <div className={cn(distribution !== 'equal' && 'md:col-span-2 xl:col-span-1')}>{third}</div>
+    </div>
+  )
+}
+
+export type SidebarWidth = 'sm' | 'md' | 'lg'
+
+export interface SidebarLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  sidebar: React.ReactNode
+  children: React.ReactNode
+  sidebarPosition?: 'left' | 'right'
+  sidebarWidth?: SidebarWidth
+  gap?: LayoutGap
+  stickySidebar?: boolean
+}
+
+const sidebarWidthClasses: Record<SidebarWidth, string> = {
+  sm: 'lg:grid-cols-[16rem_minmax(0,1fr)]',
+  md: 'lg:grid-cols-[20rem_minmax(0,1fr)]',
+  lg: 'lg:grid-cols-[24rem_minmax(0,1fr)]',
+}
+
+export function SidebarLayout({
+  sidebar,
+  children,
+  sidebarPosition = 'left',
+  sidebarWidth = 'md',
+  gap = 'lg',
+  stickySidebar = false,
+  className,
+  ...props
+}: SidebarLayoutProps) {
+  const sidebarNode = (
+    <aside className={cn(stickySidebar && 'lg:sticky lg:top-6 lg:self-start')}>{sidebar}</aside>
+  )
+
+  const mainNode = <div>{children}</div>
+
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-1 items-start',
+        sidebarWidthClasses[sidebarWidth],
+        GAP_CLASSES[gap],
+        className
+      )}
+      {...props}
+    >
+      {sidebarPosition === 'left' ? sidebarNode : mainNode}
+      {sidebarPosition === 'left' ? mainNode : sidebarNode}
+    </div>
+  )
+}
+
+export type GridTemplate = 'auto' | 'cards-2' | 'cards-3' | 'cards-4'
+
+export interface GridLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode
+  template?: GridTemplate
+  gap?: LayoutGap
+}
+
+const gridTemplateClasses: Record<GridTemplate, string> = {
+  auto: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+  'cards-2': 'grid-cols-1 md:grid-cols-2',
+  'cards-3': 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3',
+  'cards-4': 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+}
+
+export function GridLayout({
+  children,
+  template = 'auto',
+  gap = 'lg',
+  className,
+  ...props
+}: GridLayoutProps) {
+  return (
+    <div className={cn('grid', gridTemplateClasses[template], GAP_CLASSES[gap], className)} {...props}>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
 PR Summary
  This PR bundles four UI component issues into one reusable component-library pass for apps/web/components.

  - Added Badge and Tag components with variants, colors, sizes, icon support, and dismissible tags with animated removal.
  - Added Hero and Banner components with responsive CTA actions, readable gradient overlays, background image support, and hero video background
    support.
  - Added Footer and FooterSection components with company info, nav groups, social links, newsletter signup flow, legal links, and optional sticky
    footer behavior.
  - Added reusable layout templates under apps/web/components/layouts:
      - Container, Section, TwoColumnLayout, ThreeColumnLayout, SidebarLayout, GridLayout
      - Included README.md usage documentation for layout patterns.
  - Exported all new components/types from apps/web/components/index.ts.

  Validation

  - git diff --check passes for component changes.
  - Full tsc check is blocked in this workspace due missing type packages (@types/node, geojson, mapbox__point-geometry).

  Closes

  Closes #173
  Closes #185
  Closes #186
  Closes #188
