### PR TITLE
Setup: Implement No-Standard Flag

### DIFF
--- a/contracts/rent-escrow/Cargo.toml
+++ b/contracts/rent-escrow/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "22.3.0"
+soroban-sdk = "25.3.0"
 
 [dev-dependencies]
-soroban-sdk = { version = "22.3.0", features = ["testutils"] }
+soroban-sdk = { version = "25.3.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
## Summary
- Verified `#![no_std]` is set at the top of `contracts/rent-escrow/src/lib.rs`
- Updated `soroban-sdk` from `22.3.0` to `25.3.0` (old version no longer available on crates.io)
- Contract builds successfully for the `wasm32-unknown-unknown` target

## Test plan
- [x] Contract compiles with `cargo build --target wasm32-unknown-unknown --release`

Closes #326