### PR TITLE
Fix: Move release profiles to workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,15 @@ members = [
     "contracts/rent-escrow",
 ]
 resolver = "2"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug = true

--- a/contracts/rent-escrow/Cargo.toml
+++ b/contracts/rent-escrow/Cargo.toml
@@ -11,16 +11,3 @@ soroban-sdk = "25.3.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.3.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = false
-panic = "abort"
-# Optimize for size
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug = true


### PR DESCRIPTION
## Summary
- Moved `[profile.release]` and `[profile.release-with-logs]` from `contracts/rent-escrow/Cargo.toml` to the workspace root `Cargo.toml`
- Cargo ignores profile settings in non-root packages within a workspace, so the optimization flags (`opt-level = "z"`, `panic = "abort"`, `lto = true`) were not being applied
- Contract now builds with profiles correctly applied and no warning

## Test plan
- [x] `cargo build --target wasm32-unknown-unknown --release -p rent-escrow` succeeds with no profile warning

Closes #324