### PR TITLE
feat(rent-escrow): add zero-address guard to initialize - reverts if landlord is contract (issue #351)

### DIFF
--- a/contracts/rent-escrow/src/lib.rs
+++ b/contracts/rent-escrow/src/lib.rs
@@ -61,6 +61,11 @@ pub struct RentEscrowContract;
 #[contractimpl]
 impl RentEscrowContract {
     /// Initialize the escrow with landlord, rent amount, and roommates.
+    ///
+    /// Reverts if `landlord` is the contract itself.
+    ///
+    /// Persists the escrow state to ledger storage so that the values
+    /// survive across invocations and ledger closes.
     pub fn initialize(
         env: Env,
         landlord: Address,
@@ -69,6 +74,11 @@ impl RentEscrowContract {
         deadline: u64,
         roommates: Map<Address, i128>,
     ) -> Result<(), Error> {
+        // Zero-address guard: landlord must not be the contract itself
+        if landlord == env.current_contract_address() {
+            panic!("landlord cannot be the contract itself");
+        }
+
         landlord.require_auth();
 
         if rent_amount < MIN_RENT {

--- a/contracts/rent-escrow/src/test.rs
+++ b/contracts/rent-escrow/src/test.rs
@@ -246,3 +246,39 @@ fn test_initialize_accepts_min_rent() {
     // rent_amount exactly at MIN_RENT (100) must succeed
     client.initialize(&landlord, &token_address, &100_i128, &TEST_DEADLINE, &roommate_shares);
 }
+
+#[test]
+fn test_initialize_valid_landlord() {
+    let env = Env::default();
+    let contract_id = env.register(RentEscrowContract, ());
+    let client = RentEscrowContractClient::new(&env, &contract_id);
+
+    let landlord = Address::generate(&env);
+    let token_address = Address::generate(&env);
+    let roommate = Address::generate(&env);
+
+    let mut roommate_shares = Map::new(&env);
+    roommate_shares.set(roommate.clone(), 1000_i128);
+
+    env.mock_all_auths();
+    // Should succeed with a valid (non-contract) landlord address
+    client.initialize(&landlord, &token_address, &1000_i128, &TEST_DEADLINE, &roommate_shares);
+}
+
+#[test]
+#[should_panic(expected = "landlord cannot be the contract itself")]
+fn test_initialize_reverts_when_landlord_is_contract() {
+    let env = Env::default();
+    let contract_id = env.register(RentEscrowContract, ());
+    let client = RentEscrowContractClient::new(&env, &contract_id);
+
+    let token_address = Address::generate(&env);
+    let roommate = Address::generate(&env);
+
+    let mut roommate_shares = Map::new(&env);
+    roommate_shares.set(roommate.clone(), 1000_i128);
+
+    env.mock_all_auths();
+    // Passing the contract's own address as landlord must revert
+    client.initialize(&contract_id, &token_address, &1000_i128, &TEST_DEADLINE, &roommate_shares);
+}


### PR DESCRIPTION
## Summary
Closes #351 

Adds a zero-address guard to [initialize](cci:1://file:///c:/Users/HP/Documents/stellar/drips/payeasy/contracts/rent-escrow/src/lib.rs:20:4-42:5) that reverts if the provided
[landlord](cci:1://file:///c:/Users/HP/Documents/stellar/drips/payeasy/contracts/rent-escrow/src/test.rs:13:0-21:1) address equals the contract's own address.

## Changes

### [contracts/rent-escrow/src/lib.rs](cci:7://file:///c:/Users/HP/Documents/stellar/drips/payeasy/contracts/rent-escrow/src/lib.rs:0:0-0:0)
- Validates `landlord != env.current_contract_address()` at the start of [initialize](cci:1://file:///c:/Users/HP/Documents/stellar/drips/payeasy/contracts/rent-escrow/src/lib.rs:20:4-42:5)
- Panics with `"landlord cannot be the contract itself"` on failure

### [contracts/rent-escrow/src/test.rs](cci:7://file:///c:/Users/HP/Documents/stellar/drips/payeasy/contracts/rent-escrow/src/test.rs:0:0-0:0)
- [test_initialize_valid_landlord](cci:1://file:///c:/Users/HP/Documents/stellar/drips/payeasy/contracts/rent-escrow/src/test.rs:13:0-21:1) — happy path passes
- [test_initialize_reverts_when_landlord_is_contract](cci:1://file:///c:/Users/HP/Documents/stellar/drips/payeasy/contracts/rent-escrow/src/test.rs:23:0-31:1) — `#[should_panic]` confirms revert

## Checklist
- [x] Guard uses `env.current_contract_address()`
- [x] Reverts (panics) if check fails
- [x] Test for invalid address revert included
- [x] `cargo build` clean
