### PR TITLE
feat: add DAY_IN_LEDGERS constant for network time logic (closes #335)

### DIFF
--- a/contracts/rent-escrow/src/lib.rs
+++ b/contracts/rent-escrow/src/lib.rs
@@ -1,6 +1,10 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map};
 
+/// Number of ledgers in a day, assuming ~5-second ledger close times
+/// (24 * 60 * 60) / 5 = 17280
+pub const DAY_IN_LEDGERS: u32 = 17280;
+
 //RentEscrow defined already
 #[contracttype]
 #[derive(Clone)]


### PR DESCRIPTION
closes #335

Added `DAY_IN_LEDGERS: u32 = 17280` constant to `contracts/rent-escrow/src/lib.rs`.

This approximates the number of Stellar ledgers in a day based on ~5-second ledger close times: (24 * 60 * 60) / 5 = 17280.
