### PR TITLE
feat(storage): implement persistent storage for landlord and amount

### DIFF
--- a/contracts/rent-escrow/src/lib.rs
+++ b/contracts/rent-escrow/src/lib.rs
@@ -39,7 +39,15 @@ impl RentEscrowContract {
         env.storage().persistent().set(&DataKey::Amount, &amount);
     }
 
-    /// Update the escrow amount. Only callable by the stored landlord.
+    /// Update the escrow amount.
+    ///
+    /// Reads the stored landlord from persistent storage and verifies that
+    /// `caller` matches before allowing the write.
+    ///
+    /// # Arguments
+    /// * `env`        - The Soroban environment handle.
+    /// * `caller`     - The invoker's `Address`; must equal the stored landlord.
+    /// * `new_amount` - Replacement escrow amount in stroops (i128).
     pub fn set_amount(env: Env, caller: Address, new_amount: i128) {
         caller.require_auth();
         let landlord: Address = env.storage()
@@ -50,13 +58,30 @@ impl RentEscrowContract {
         env.storage().persistent().set(&DataKey::Amount, &new_amount);
     }
 
-    /// Placeholder - retrieval logic added in the next commit.
-    pub fn get_landlord(_env: Env) -> Address {
-        panic!("not implemented")
+    /// Retrieve the landlord address from persistent storage.
+    ///
+    /// Panics with a descriptive message if `initialize` has not been called.
+    ///
+    /// # Returns
+    /// The `Address` of the landlord stored during initialization.
+    pub fn get_landlord(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Landlord)
+            .expect("landlord not set; call initialize first")
     }
 
-    /// Placeholder - retrieval logic added in the next commit.
-    pub fn get_amount(_env: Env) -> i128 {
-        0
+    /// Retrieve the current escrow amount from persistent storage.
+    ///
+    /// Returns `0` if `initialize` has not yet been called, which is a safe
+    /// default for an unsigned integer-style amount field.
+    ///
+    /// # Returns
+    /// The escrowed amount in stroops as `i128`.
+    pub fn get_amount(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Amount)
+            .unwrap_or(0)
     }
 }


### PR DESCRIPTION
## Summary

Closes #353.

This PR implements persistent ledger storage for the landlord address and amount fields in the rent-escrow Soroban smart contract, so that their values survive across transaction invocations and ledger closes.

---

## Storage approach

### Key structure

A #[contracttype] enum DataKey is introduced as the canonical key type:

- DataKey::Landlord -> Address
- DataKey::Amount -> i128

Using a typed enum instead of raw Symbol literals:
- prevents key collisions across future storage slots
- enables the Soroban SDK XDR codec to serialise keys deterministically
- makes it trivial to extend the key space without risk of shadowing

### How persistence works

Soroban provides three storage tiers: temporary, instance, and persistent.
This implementation uses env.storage().persistent() because:

- Persistent storage survives ledger closes indefinitely (subject to rent payments)
- temporary storage is erased after a TTL and is unsuitable for critical state
- instance storage is tied to the contract instance; persistent is more flexible

### Write path (initialize / set_amount)

Both writes happen atomically within a single transaction invocation.

### Read path (get_landlord / get_amount)

get_landlord uses expect() because returning a default Address would be meaningless. get_amount uses unwrap_or(0) because zero is an unambiguous not-yet-set sentinel.

---

## Commit breakdown

| Commit | Change |
|--------|--------|
| feat(storage): define persistent storage keys | Introduces DataKey enum; stubs out function bodies |
| feat(storage): store landlord and amount | Implements initialize and set_amount with .persistent().set() |
| feat(storage): add retrieval logic | Implements get_landlord and get_amount with .persistent().get() |

---

## Testing checklist

- [ ] initialize stores landlord and amount correctly
- [ ] set_amount rejects callers that are not the stored landlord
- [ ] get_amount returns 0 before initialize is called
- [ ] get_landlord panics with a clear message before initialize is called
- [ ] Contract compiles with cargo build --target wasm32-unknown-unknown --release
