### PR TITLE
Logic: Update Paid Balance #373

### DIFF
--- a/contracts/rent-escrow/src/lib.rs
+++ b/contracts/rent-escrow/src/lib.rs
@@ -26,14 +26,20 @@ pub enum DataKey {
     Escrow,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoommateState {
+    pub expected: i128,
+    pub paid: i128,
+}
+
 /// The rent escrow data structure.
 #[contracttype]
 #[derive(Clone)]
 pub struct RentEscrow {
     pub landlord: Address,
     pub rent_amount: i128,
-    pub roommates: Map<Address, i128>,
-    pub contributions: Map<Address, i128>,
+    pub roommates: Map<Address, RoommateState>,
 }
 
 #[contract]
@@ -57,11 +63,18 @@ impl RentEscrowContract {
             return Err(Error::InvalidAmount);
         }
 
+        let mut roommate_states = Map::new(&env);
+        for (address, expected) in roommates.iter() {
+            roommate_states.set(address, RoommateState {
+                expected,
+                paid: 0,
+            });
+        }
+
         env.storage().persistent().set(&DataKey::Escrow, &RentEscrow {
             landlord,
             rent_amount,
-            roommates,
-            contributions: Map::new(&env),
+            roommates: roommate_states,
         });
 
         Ok(())
@@ -80,12 +93,9 @@ impl RentEscrowContract {
             .get(&DataKey::Escrow)
             .expect("escrow not initialized");
 
-        if !escrow.roommates.contains_key(from.clone()) {
-            return Err(Error::InvalidAmount);
-        }
-
-        let current: i128 = escrow.contributions.get(from.clone()).unwrap_or(0);
-        escrow.contributions.set(from.clone(), current + amount);
+        let mut state = escrow.roommates.get(from.clone()).ok_or(Error::InvalidAmount)?;
+        state.paid += amount;
+        escrow.roommates.set(from.clone(), state);
 
         env.storage().persistent().set(&DataKey::Escrow, &escrow);
 
@@ -100,24 +110,21 @@ impl RentEscrowContract {
             .expect("escrow not initialized");
 
         let mut total: i128 = 0;
-        for (_, amount) in escrow.contributions.iter() {
-            total += amount;
+        for (_, state) in escrow.roommates.iter() {
+            total += state.paid;
         }
         total
     }
 
     /// Check whether the total contributions meet or exceed the rent goal.
     pub fn is_fully_funded(env: Env) -> bool {
+        let total_funded = Self::get_total_funded(env);
         let escrow: RentEscrow = env.storage()
             .persistent()
             .get(&DataKey::Escrow)
             .expect("escrow not initialized");
 
-        let mut total: i128 = 0;
-        for (_, amount) in escrow.contributions.iter() {
-            total += amount;
-        }
-        total >= escrow.rent_amount
+        total_funded >= escrow.rent_amount
     }
 
     /// Release total rent to the landlord if fully funded.
@@ -156,6 +163,19 @@ impl RentEscrowContract {
             .get(&DataKey::Escrow);
         match result {
             Some(escrow) => escrow.rent_amount,
+            None => 0,
+        }
+    }
+
+    /// Retrieve the paid balance for a specific roommate.
+    pub fn get_balance(env: Env, from: Address) -> i128 {
+        let escrow: RentEscrow = env.storage()
+            .persistent()
+            .get(&DataKey::Escrow)
+            .expect("escrow not initialized");
+
+        match escrow.roommates.get(from) {
+            Some(state) => state.paid,
             None => 0,
         }
     }

--- a/contracts/rent-escrow/src/test.rs
+++ b/contracts/rent-escrow/src/test.rs
@@ -72,3 +72,17 @@ fn test_is_fully_funded_with_overfunding() {
     assert_eq!(client.get_total_funded(), 1100_i128);
     assert_eq!(client.is_fully_funded(), true);
 }
+
+#[test]
+fn test_get_balance() {
+    let env = Env::default();
+    let (client, _, roommate_a, _) = setup_escrow(&env);
+
+    assert_eq!(client.get_balance(&roommate_a), 0_i128);
+
+    client.contribute(&roommate_a, &200_i128);
+    assert_eq!(client.get_balance(&roommate_a), 200_i128);
+
+    client.contribute(&roommate_a, &150_i128);
+    assert_eq!(client.get_balance(&roommate_a), 350_i128);
+}


### PR DESCRIPTION
## Pull Request: Logic: Update Paid Balance

### Description
This PR implements the logic for tracking and updating roommate paid balances as part of Issue #373 . It introduces a structured state for roommates and refactors the escrow contract for better data management.

### Key Changes
- RoommateState Struct: Added a new RoommateState #[contracttype] to store both expected rent shares and paid amounts for each roommate.
- Contract Refactoring: Updated the RentEscrow struct to use a single roommates: Map<Address, RoommateState> instead of separate maps for shares and contributions
- Updated initialize: Modified to populate the roommates map with initial RoommateState (expected share set, paid balance at 0).
- Updated contribute: Refined the logic to increment the paid balance within the RoommateState and save it back to the map
- New Getter: Added get_balance(env, address) to allow participants to query their current contribution status
- Unit Testing: Added test_get_balance to test.rs to verify that balances are correctly initialized and incremented after deposits.

### Verification
- Added a new unit test test_get_balance covering initial state and multiple deposits
- Logic verified for consistency with the established zero-float policy and Soroban storage patterns.
Closes #373 