### PR TITLE
feat(rent-escrow): add Shares and Contributions keys to DataKey (issue #346)

### DIFF
--- a/contracts/rent-escrow/src/lib.rs
+++ b/contracts/rent-escrow/src/lib.rs
@@ -26,6 +26,10 @@ pub enum Error {
 pub enum DataKey {
     Escrow,
     Deadline,
+    /// Maps a roommate Address to their expected rent share (i128).
+    Shares(Address),
+    /// Maps a roommate Address to their total contributed amount (i128).
+    Contributions(Address),
 }
 
 /// Tracks an individual roommate's rent obligation and payment progress.


### PR DESCRIPTION
 ## feat(rent-escrow): Add Roommate Storage Keys to DataKey (Issue #346)

  ### What was done

  Modified `contracts/rent-escrow/src/lib.rs` to add two new variants to the `DataKey` enum:

  - `Shares(Address)` — maps a roommate's address to their expected rent share (`i128`)
  - `Contributions(Address)` — maps a roommate's address to their total contributed amount (`i128`)

  ### Why

  The `DataKey` enum is the contract's type-safe storage key system. Previously it only had an `Escrow` key for the
  top-level escrow struct. To support per-roommate lookups without going through the full `RentEscrow` struct, dedicated
   keyed variants are needed.

  Using `Address` as a tuple parameter on each variant means every roommate gets their own unique storage slot, e.g.:
  - `DataKey::Shares(roommate_a)` → `500_i128`
  - `DataKey::Contributions(roommate_a)` → `300_i128`

  This pattern is idiomatic Soroban — `#[contracttype]` serialises the variant + address into a collision-free ledger
  key.

  ### Files Modified

  | File | Change |
  |------|--------|
  | `contracts/rent-escrow/src/lib.rs` | Added `Shares(Address)` and `Contributions(Address)` to `DataKey` 
  
  
  
Closes #346 