### PR TITLE
 Implement auto-save form draft to localStorage for escrow creation

### DIFF
--- a/components/escrow/CreateEscrowForm.tsx
+++ b/components/escrow/CreateEscrowForm.tsx
@@ -6,6 +6,7 @@ import { createEscrow } from "@/lib/mock/escrow";
 
 import { getExplorerLink, type ExplorerProvider } from "@/lib/stellar/explorer";
 
+import { useFormDraft } from "@/hooks/useFormDraft";
 import RoommateInput from "./RoommateInput";
 import {
   hasExactShareAllocation,
@@ -117,11 +118,21 @@ export default function CreateEscrowForm({
 }: CreateEscrowFormProps) {
   const router = useRouter();
   const [step, setStep] = useState(1);
-  const [draft, setDraft] = useState<EscrowFormDraft>({
-    totalRent: "",
-    tokenId: "",
-    deadlineDate: "",
-    roommates: [createRoommate()],
+  const {
+    values: draft,
+    setValues: setDraft,
+    hasDraft,
+    loadDraft,
+    discardDraft,
+    clearDraft,
+  } = useFormDraft<EscrowFormDraft>({
+    key: "escrow_create_draft",
+    initialValues: {
+      totalRent: "",
+      tokenId: "",
+      deadlineDate: "",
+      roommates: [createRoommate()],
+    },
   });
   const [errors, setErrors] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -212,6 +223,9 @@ export default function CreateEscrowForm({
       // Call the mock service
       const { contractId } = await createEscrow();
 
+      // Clear draft on successful submission
+      clearDraft();
+
       // Redirect to success page
       router.push(`/escrow/success?id=${contractId}`);
     } catch (error) {
@@ -226,6 +240,28 @@ export default function CreateEscrowForm({
 
   return (
     <section className="max-w-3xl mx-auto rounded-3xl glass p-6 sm:p-8">
+      {hasDraft && (
+        <div className="mb-6 flex flex-col sm:flex-row items-center justify-between gap-4 rounded-xl border border-brand-400/40 bg-brand-500/10 p-4 text-sm animate-fade-in">
+          <p className="text-brand-100 font-medium">You have an unsaved draft. Resume?</p>
+          <div className="flex items-center gap-3 w-full sm:w-auto">
+            <button
+              type="button"
+              onClick={discardDraft}
+              className="flex-1 sm:flex-none rounded-lg px-4 py-2 text-dark-300 hover:text-dark-100 hover:bg-white/5 transition-colors"
+            >
+              Discard
+            </button>
+            <button
+              type="button"
+              onClick={loadDraft}
+              className="flex-1 sm:flex-none rounded-lg bg-brand-500 px-4 py-2 text-white font-medium hover:bg-brand-400 transition-colors"
+            >
+              Resume
+            </button>
+          </div>
+        </div>
+      )}
+
       <header className="mb-6 space-y-2">
         <p className="text-xs uppercase tracking-[0.2em] text-brand-300">
           Escrow Setup

--- a/hooks/useFormDraft.ts
+++ b/hooks/useFormDraft.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+type UseFormDraftOptions<T> = {
+  key: string;
+  initialValues: T;
+};
+
+export const useFormDraft = <T>({ key, initialValues }: UseFormDraftOptions<T>) => {
+  const [values, setValues] = useState<T>(initialValues);
+  const [hasDraft, setHasDraft] = useState(false);
+  
+  const isInitialMount = useRef(true);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Check for draft on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(key);
+      if (saved) {
+        // Validate JSON and check if it's not strictly equal to initial empty state
+        const parsed = JSON.parse(saved);
+        if (parsed && Object.keys(parsed).length > 0) {
+          setHasDraft(true);
+        }
+      }
+    } catch (e) {
+      // Corrupted JSON
+      localStorage.removeItem(key);
+    }
+  }, [key]);
+
+  // Save to draft on values change with debounce
+  useEffect(() => {
+    // Skip saving on initial mount
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      try {
+        localStorage.setItem(key, JSON.stringify(values));
+        // If the user started modifying the form instead of resuming,
+        // the draft is overwritten, so we can hide the banner.
+        setHasDraft(false);
+      } catch (e) {
+        // Handle storage quota exceeded or other errors silently in UI
+      }
+    }, 1000);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [values, key]);
+
+  const loadDraft = useCallback(() => {
+    try {
+      const saved = localStorage.getItem(key);
+      if (saved) {
+        setValues(JSON.parse(saved));
+        setHasDraft(false);
+      }
+    } catch (e) {
+      localStorage.removeItem(key);
+    }
+  }, [key]);
+
+  const discardDraft = useCallback(() => {
+    localStorage.removeItem(key);
+    setHasDraft(false);
+  }, [key]);
+
+  const clearDraft = useCallback(() => {
+    localStorage.removeItem(key);
+    setHasDraft(false);
+  }, [key]);
+
+  return {
+    values,
+    setValues,
+    hasDraft,
+    loadDraft,
+    discardDraft,
+    clearDraft,
+  };
+};


### PR DESCRIPTION
Closes #493

## 🎯 Objective
This PR introduces an auto-save functionality for the escrow creation flow. It automatically saves the user's form progress to `localStorage` and allows them to seamlessly resume their draft after a page reload, preventing accidental data loss.

## 🛠️ Changes Made
- **Created `useFormDraft` hook** (`hooks/useFormDraft.ts`): 
  - Encapsulates all `localStorage` logic (save, load, discard, clear).
  - Implements a 1-second debounce to prevent excessive storage writes.
  - Safely handles JSON parsing and corrupted data.
- **Updated `CreateEscrowForm` component** (`components/escrow/CreateEscrowForm.tsx`):
  - Replaced local form state with the new `useFormDraft` hook using the `escrow_create_draft` key.
  - Added a responsive, animated UI banner that prompts users to **Resume** or **Discard** an existing draft upon page load.
  - Wired up `clearDraft()` to execute upon successful escrow submission.

## 🧪 How to Test
1. Navigate to the Create Escrow page and fill out a few fields.
2. Refresh the page.
3. Observe the "You have an unsaved draft. Resume?" banner at the top.
4. Click **Resume** to verify the fields populate correctly, or **Discard** to start fresh.
5. Complete the form and submit it; verify that the draft is successfully cleared from `localStorage`.