### PR TITLE
 Implement Global Stellar Authentication Context

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { AppShell } from "@/components/ui/app-shell";
+import { StellarAuthProvider } from "@/contexts/StellarAuthContext";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -31,7 +32,9 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
-        <AppShell>{children}</AppShell>
+        <StellarAuthProvider>
+          <AppShell>{children}</AppShell>
+        </StellarAuthProvider>
       </body>
     </html>
   );

--- a/contexts/StellarAuthContext.tsx
+++ b/contexts/StellarAuthContext.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect, useMemo, useCallback } from "react";
+
+// --- Internal Hook Abstraction ---
+const useFreighterWallet = () => {
+  const mockPublicKey = "GABC1234MOCKWALLETXYZ";
+
+  const connect = useCallback(async (): Promise<string> => {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(mockPublicKey), 500);
+    });
+  }, []);
+
+  const disconnect = useCallback((): void => {
+    // Mock disconnect logic
+  }, []);
+
+  return { connect, disconnect };
+};
+
+// --- Context Definition ---
+export type StellarAuthContextType = {
+  publicKey: string | null;
+  isConnected: boolean;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+};
+
+const StellarAuthContext = createContext<StellarAuthContextType | undefined>(undefined);
+
+// --- Provider Component ---
+const STORAGE_KEY = "stellar_wallet_connection";
+
+export const StellarAuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState<boolean>(false);
+  const { connect: mockConnect, disconnect: mockDisconnect } = useFreighterWallet();
+
+  // Rehydrate state on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const data = JSON.parse(stored);
+        if (data && typeof data.publicKey === "string") {
+          setPublicKey(data.publicKey);
+          setIsConnected(true);
+        }
+      }
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (isConnected) return;
+    try {
+      const key = await mockConnect();
+      setPublicKey(key);
+      setIsConnected(true);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ publicKey: key }));
+    } catch (error) {
+      throw error;
+    }
+  }, [isConnected, mockConnect]);
+
+  const disconnect = useCallback(() => {
+    mockDisconnect();
+    setPublicKey(null);
+    setIsConnected(false);
+    localStorage.removeItem(STORAGE_KEY);
+  }, [mockDisconnect]);
+
+  const value = useMemo(
+    () => ({
+      publicKey,
+      isConnected,
+      connect,
+      disconnect,
+    }),
+    [publicKey, isConnected, connect, disconnect]
+  );
+
+  return <StellarAuthContext.Provider value={value}>{children}</StellarAuthContext.Provider>;
+};
+
+// --- Custom Hook ---
+export const useStellarAuth = () => {
+  const context = useContext(StellarAuthContext);
+  if (context === undefined) {
+    throw new Error("useStellarAuth must be used within a StellarAuthProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
Closes #415

### Description
This PR introduces a scalable `StellarAuthProvider` to manage wallet connection state globally across the PayEasy application. It includes an abstracted mock implementation of the Freighter wallet connection, ensuring the frontend architecture is ready for real wallet integration while currently supporting state persistence and auto-reconnection.

### Changes Made
* **Added `StellarAuthContext`**: Created `contexts/StellarAuthContext.tsx` providing a global React Context and a `useStellarAuth` hook for accessing wallet state.
* **Mock Wallet Abstraction**: Implemented an internal `useFreighterWallet` hook to simulate connect/disconnect functionality and network delays.
* **State Persistence**: Added `localStorage` support (via the `"stellar_wallet_connection"` key) to persist the user's connection across page reloads and handle auto-rehydration on mount.
* **Global Provider Integration**: Updated `app/layout.tsx` to wrap the entire application within `<StellarAuthProvider>`, making the wallet state accessible to all components.

### Testing / Verification
* Verified default states (disconnected, null public key).
* Confirmed that connecting sets the mock public key and updates `localStorage`.
* Verified that state rehydration works correctly on page reload without Next.js SSR hydration mismatches.
* Ensured `useStellarAuth` throws a descriptive error if used outside of the provider.