### PR TITLE
Map wallet error codes to human-readable messages with expandable help text

### DIFF
--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   LogOut,
   ChevronRight,
+  ChevronDown,
 } from "lucide-react";
 import Link from "next/link";
 import { useStellar } from "@/context/StellarContext";
@@ -56,6 +57,7 @@ export default function ConnectWalletPage() {
   const [copied, setCopied] = useState(false);
   const [step, setStep] = useState<Step>("intro");
   const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
+  const [errorExpanded, setErrorExpanded] = useState(false);
 
   useEffect(() => {
     if (isConnected && publicKey) {
@@ -223,11 +225,32 @@ export default function ConnectWalletPage() {
                 <motion.div
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
-                  className="w-full mt-4 glass-card p-4 flex items-start gap-3 border-red-500/20"
+                  className="w-full mt-4 glass-card p-4 border-red-500/20 space-y-2"
                   style={{ borderColor: "rgba(239,68,68,0.2)" }}
                 >
-                  <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
-                  <p className="text-red-300 text-sm">{error}</p>
+                  <div className="flex items-start gap-3">
+                    <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+                    <p className="text-red-300 text-sm flex-1">{error.message}</p>
+                  </div>
+                  <button
+                    onClick={() => setErrorExpanded((v) => !v)}
+                    className="flex items-center gap-1.5 text-xs text-dark-400 hover:text-dark-200 transition-colors ml-8"
+                  >
+                    <ChevronDown
+                      size={14}
+                      className={`transition-transform ${errorExpanded ? "rotate-180" : ""}`}
+                    />
+                    What does this mean?
+                  </button>
+                  {errorExpanded && (
+                    <motion.p
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      className="text-xs text-dark-400 leading-relaxed ml-8 border-l border-white/10 pl-3"
+                    >
+                      {error.help}
+                    </motion.p>
+                  )}
                 </motion.div>
               )}
 

--- a/components/wallet/ConnectWalletButton.tsx
+++ b/components/wallet/ConnectWalletButton.tsx
@@ -3,14 +3,15 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
-import { Wallet, LogOut, Copy, Check, ChevronDown, ExternalLink } from "lucide-react";
+import { Wallet, LogOut, Copy, Check, ChevronDown, ExternalLink, AlertCircle } from "lucide-react";
 import { useStellarAuth } from "@/context/StellarContext";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 export default function ConnectWalletButton() {
-  const { publicKey, isConnected, connect, disconnect, isConnecting, isFreighterInstalled, isRestoring } = useStellarAuth();
+  const { publicKey, isConnected, connect, disconnect, isConnecting, isFreighterInstalled, isRestoring, error } = useStellarAuth();
   const [isOpen, setIsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [errorExpanded, setErrorExpanded] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const [showConfirm, setShowConfirm] = useState(false);
@@ -62,20 +63,42 @@ export default function ConnectWalletButton() {
 
   if (!isConnected) {
     return (
-      <button
-        onClick={() => {
-          if (!isFreighterInstalled) {
-            router.push("/connect");
-          } else {
-            connect();
-          }
-        }}
-        disabled={isConnecting}
-        className="btn-primary !py-2.5 !px-5 !text-sm !rounded-lg flex items-center gap-2 group transition-all hover:scale-105 active:scale-95 disabled:opacity-50"
-      >
-        <Wallet size={16} className="group-hover:rotate-12 transition-transform" />
-        {isConnecting ? "Connecting..." : "Connect Wallet"}
-      </button>
+      <div className="flex flex-col items-end gap-1">
+        <button
+          onClick={() => {
+            if (!isFreighterInstalled) {
+              router.push("/connect");
+            } else {
+              connect();
+            }
+          }}
+          disabled={isConnecting}
+          className="btn-primary !py-2.5 !px-5 !text-sm !rounded-lg flex items-center gap-2 group transition-all hover:scale-105 active:scale-95 disabled:opacity-50"
+        >
+          <Wallet size={16} className="group-hover:rotate-12 transition-transform" />
+          {isConnecting ? "Connecting..." : "Connect Wallet"}
+        </button>
+
+        {error && (
+          <div className="text-right max-w-[220px]">
+            <div className="flex items-center justify-end gap-1.5">
+              <AlertCircle size={12} className="text-red-400 shrink-0" />
+              <p className="text-xs text-red-400">{error.message}</p>
+            </div>
+            <button
+              onClick={() => setErrorExpanded((v) => !v)}
+              className="text-[11px] text-dark-500 hover:text-dark-300 transition-colors mt-0.5"
+            >
+              {errorExpanded ? "Hide details" : "What does this mean?"}
+            </button>
+            {errorExpanded && (
+              <p className="text-[11px] text-dark-500 leading-relaxed mt-1 border-l border-white/10 pl-2 text-left">
+                {error.help}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
     );
   }
 

--- a/context/StellarContext.tsx
+++ b/context/StellarContext.tsx
@@ -7,6 +7,7 @@ import {
   getPublicKey as fetchPublicKey,
   checkConnection
 } from "@/lib/stellar/wallet";
+import { getWalletError, type WalletError } from "@/lib/stellar/errors";
 
 interface StellarContextType {
   publicKey: string | null;
@@ -16,7 +17,7 @@ interface StellarContextType {
   isRestoring: boolean;
   connect: () => Promise<void>;
   disconnect: () => void;
-  error: string | null;
+  error: WalletError | null;
 }
 
 const StellarContext = createContext<StellarContextType | undefined>(undefined);
@@ -27,7 +28,7 @@ export function StellarProvider({ children }: { children: React.ReactNode }) {
   const [isFreighterInstalled, setIsFreighterInstalled] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isRestoring, setIsRestoring] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<WalletError | null>(null);
 
   // Initialize connection state
   useEffect(() => {
@@ -74,7 +75,7 @@ export function StellarProvider({ children }: { children: React.ReactNode }) {
         throw new Error("User rejected connection or failed to retrieve public key.");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to connect wallet.");
+      setError(getWalletError(err));
       setIsConnected(false);
       setPublicKey(null);
     } finally {

--- a/lib/stellar/errors.test.js
+++ b/lib/stellar/errors.test.js
@@ -1,10 +1,68 @@
 import { describe, it as test } from "node:test";
 import assert from "node:assert";
-import { translateStellarError, StellarErrorType } from "./errors.ts";
+import { translateStellarError, StellarErrorType, getWalletError, WalletErrorCode } from "./errors.ts";
 
 const expect = (actual) => ({
   toBe: (expected) => assert.strictEqual(actual, expected),
   toContain: (expected) => assert.ok(actual?.includes(expected) || actual?.message?.includes(expected)),
+});
+
+describe("getWalletError", () => {
+  test("USER_DECLINED: maps 'User declined' message", () => {
+    const result = getWalletError(new Error("User declined transaction"));
+    assert.strictEqual(result.code, WalletErrorCode.USER_DECLINED);
+    assert.strictEqual(result.message, "You declined the connection request.");
+  });
+
+  test("USER_DECLINED: maps 'reject' message", () => {
+    const result = getWalletError(new Error("user rejected the request"));
+    assert.strictEqual(result.code, WalletErrorCode.USER_DECLINED);
+  });
+
+  test("NOT_INSTALLED: maps 'Freighter extension not found' message", () => {
+    const result = getWalletError(new Error("Freighter extension not found. Please install it to continue."));
+    assert.strictEqual(result.code, WalletErrorCode.NOT_INSTALLED);
+    assert.strictEqual(result.message, "Freighter wallet is not installed.");
+  });
+
+  test("NOT_INSTALLED: maps 'not installed' string", () => {
+    const result = getWalletError("wallet not installed");
+    assert.strictEqual(result.code, WalletErrorCode.NOT_INSTALLED);
+  });
+
+  test("NETWORK_MISMATCH: maps 'network mismatch' message", () => {
+    const result = getWalletError(new Error("network mismatch detected"));
+    assert.strictEqual(result.code, WalletErrorCode.NETWORK_MISMATCH);
+    assert.strictEqual(result.message, "Your wallet is on the wrong network.");
+  });
+
+  test("NETWORK_MISMATCH: maps 'wrong network' message", () => {
+    const result = getWalletError(new Error("wrong network selected"));
+    assert.strictEqual(result.code, WalletErrorCode.NETWORK_MISMATCH);
+  });
+
+  test("UNKNOWN: maps unrecognised error to generic fallback", () => {
+    const result = getWalletError(new Error("some completely unexpected sdk error"));
+    assert.strictEqual(result.code, WalletErrorCode.UNKNOWN);
+    assert.strictEqual(result.message, "Something went wrong connecting your wallet.");
+  });
+
+  test("UNKNOWN: handles null gracefully", () => {
+    const result = getWalletError(null);
+    assert.strictEqual(result.code, WalletErrorCode.UNKNOWN);
+  });
+
+  test("each error code has non-empty help text", () => {
+    Object.values(WalletErrorCode).forEach((code) => {
+      const result = getWalletError(
+        code === WalletErrorCode.USER_DECLINED ? new Error("declined") :
+        code === WalletErrorCode.NOT_INSTALLED ? new Error("not found") :
+        code === WalletErrorCode.NETWORK_MISMATCH ? new Error("network mismatch") :
+        null
+      );
+      assert.ok(result.help.length > 0, `help text missing for ${code}`);
+    });
+  });
 });
 
 describe("translateStellarError", () => {

--- a/lib/stellar/errors.ts
+++ b/lib/stellar/errors.ts
@@ -3,6 +3,71 @@
  * Centralized error handler that translates Stellar/Soroban errors into user-friendly messages.
  */
 
+// ─── Wallet-specific error codes ────────────────────────────────────────────
+
+export const WalletErrorCode = {
+  USER_DECLINED: "USER_DECLINED",
+  NOT_INSTALLED: "NOT_INSTALLED",
+  NETWORK_MISMATCH: "NETWORK_MISMATCH",
+  UNKNOWN: "UNKNOWN",
+} as const;
+
+export type WalletErrorCode = (typeof WalletErrorCode)[keyof typeof WalletErrorCode];
+
+export interface WalletError {
+  code: WalletErrorCode;
+  message: string;
+  help: string;
+}
+
+export const WALLET_ERROR_MESSAGES: Record<WalletErrorCode, WalletError> = {
+  [WalletErrorCode.USER_DECLINED]: {
+    code: WalletErrorCode.USER_DECLINED,
+    message: "You declined the connection request.",
+    help: "The Freighter popup appeared but was dismissed or rejected. Open the popup again and click 'Connect' to allow PayEasy access to your wallet.",
+  },
+  [WalletErrorCode.NOT_INSTALLED]: {
+    code: WalletErrorCode.NOT_INSTALLED,
+    message: "Freighter wallet is not installed.",
+    help: "PayEasy requires the Freighter browser extension to interact with the Stellar network. Visit freighter.app to install it, then refresh this page.",
+  },
+  [WalletErrorCode.NETWORK_MISMATCH]: {
+    code: WalletErrorCode.NETWORK_MISMATCH,
+    message: "Your wallet is on the wrong network.",
+    help: "PayEasy runs on Stellar Testnet. Open Freighter, go to Settings → Network, and switch to 'Testnet' before connecting.",
+  },
+  [WalletErrorCode.UNKNOWN]: {
+    code: WalletErrorCode.UNKNOWN,
+    message: "Something went wrong connecting your wallet.",
+    help: "An unexpected error occurred. Try refreshing the page or reconnecting your wallet. If the problem persists, check that Freighter is up to date.",
+  },
+};
+
+/**
+ * Maps a raw error from Freighter/wallet operations to a structured WalletError.
+ */
+export function getWalletError(error: unknown): WalletError {
+  const msg =
+    error instanceof Error
+      ? error.message.toLowerCase()
+      : typeof error === "string"
+      ? error.toLowerCase()
+      : "";
+
+  if (msg.includes("declined") || msg.includes("reject") || msg.includes("user rejected")) {
+    return WALLET_ERROR_MESSAGES[WalletErrorCode.USER_DECLINED];
+  }
+  if (msg.includes("not found") || msg.includes("not installed") || msg.includes("freighter extension not found")) {
+    return WALLET_ERROR_MESSAGES[WalletErrorCode.NOT_INSTALLED];
+  }
+  if (msg.includes("network") || msg.includes("mismatch") || msg.includes("wrong network")) {
+    return WALLET_ERROR_MESSAGES[WalletErrorCode.NETWORK_MISMATCH];
+  }
+  return WALLET_ERROR_MESSAGES[WalletErrorCode.UNKNOWN];
+}
+
+// ─── Soroban / Stellar error types ──────────────────────────────────────────
+
 export const StellarErrorType = {
   INVALID_AMOUNT: "InvalidAmount",
   INSUFFICIENT_FUNDING: "InsufficientFunding",


### PR DESCRIPTION
## Summary

Replaces raw Freighter/SDK error strings with structured, user-friendly messages and adds expandable "What does this mean?" help text per error.

this pr Closes #463 

## Changes

- `lib/stellar/errors.ts` — Added `WalletErrorCode` enum, `WALLET_ERROR_MESSAGES` map, and `getWalletError()` helper covering `USER_DECLINED`, `NOT_INSTALLED`, `NETWORK_MISMATCH`, and `UNKNOWN`
- `context/StellarContext.tsx` — `error` state now holds a `WalletError` object instead of a raw string; uses `getWalletError()` on catch
- `app/connect/page.tsx` — Error display uses `error.message` (mapped) and renders a collapsible "What does this mean?" section with `error.help`
- `components/wallet/ConnectWalletButton.tsx` — Shows mapped error message + expandable help text below the connect button on failure
- `lib/stellar/errors.test.js` — Unit tests for all four wallet error codes, string inputs, null input, and help text presence

## Acceptance Criteria

- [x] Declining the Freighter popup shows "You declined the connection request."
- [x] Missing extension shows "Freighter wallet is not installed."
- [x] Wrong network shows "Your wallet is on the wrong network."
- [x] Unknown errors show generic fallback — no raw SDK text exposed
- [x] Every error has expandable help text explaining what to do
