### PR TITLE
feat(escrow): show estimated network fee on review step (#499)

### DIFF
--- a/components/escrow/CreateEscrowForm.test.ts
+++ b/components/escrow/CreateEscrowForm.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   calculateRemainingAmount,
+  formatFeeEstimate,
   nextEscrowStep,
   previousEscrowStep,
   toLedgerTimestamp,
@@ -80,4 +81,17 @@ test("calculateRemainingAmount handles excess allocation", () => {
   ];
   const remaining = calculateRemainingAmount("1000", roommates);
   assert.equal(remaining, -100);
+});
+
+test("formatFeeEstimate renders the fee in the review step copy", () => {
+  assert.equal(
+    formatFeeEstimate("0.00001"),
+    "Estimated network fee: ~0.00001 XLM"
+  );
+});
+
+test("formatFeeEstimate falls back to 'Fee unavailable' when fee fetch fails", () => {
+  assert.equal(formatFeeEstimate(null), "Fee unavailable");
+  assert.equal(formatFeeEstimate(undefined), "Fee unavailable");
+  assert.equal(formatFeeEstimate(""), "Fee unavailable");
 });

--- a/components/escrow/CreateEscrowForm.tsx
+++ b/components/escrow/CreateEscrowForm.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createEscrow } from "@/lib/mock/escrow";
 
 import { getExplorerLink, type ExplorerProvider } from "@/lib/stellar/explorer";
+import { getFeeStats } from "@/lib/stellar/queries";
 
 import { useFormDraft } from "@/hooks/useFormDraft";
 import { useBeforeUnload } from "@/hooks/useBeforeUnload";
 import RoommateInput from "./RoommateInput";
 import {
   calculateRemainingAmount,
+  formatFeeEstimate,
   hasExactShareAllocation,
   nextEscrowStep,
   previousEscrowStep,
@@ -153,9 +155,34 @@ export default function CreateEscrowForm({
   const [errors, setErrors] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submission, setSubmission] = useState<SubmissionState | null>(null);
+  const [feeEstimateXlm, setFeeEstimateXlm] = useState<string | null>(null);
+  const [feeStatus, setFeeStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
 
   // Warn before unload if there are unsaved changes and we haven't submitted
   useBeforeUnload(isDirty && !submission);
+
+  useEffect(() => {
+    if (step !== 4) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setFeeStatus("loading");
+
+    getFeeStats("testnet", undefined, { signal: controller.signal })
+      .then((stats) => {
+        if (controller.signal.aborted) return;
+        setFeeEstimateXlm(stats.baseFeeXlm);
+        setFeeStatus("ready");
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setFeeEstimateXlm(null);
+        setFeeStatus("error");
+      });
+
+    return () => controller.abort();
+  }, [step]);
 
   const totalRoommateShares = useMemo(
     () => sumRoommateShares(draft.roommates),
@@ -470,6 +497,15 @@ export default function CreateEscrowForm({
                 ))}
               </ul>
             </div>
+
+            <p
+              data-testid="fee-estimate"
+              className={feeStatus === "error" ? "text-dark-500" : "text-dark-300"}
+            >
+              {feeStatus === "loading"
+                ? "Estimating network fee..."
+                : formatFeeEstimate(feeStatus === "ready" ? feeEstimateXlm : null)}
+            </p>
 
             {submission ? (
               <div className="rounded-xl border border-accent-500/40 bg-accent-500/10 p-4 text-accent-100 space-y-2">

--- a/components/escrow/createEscrowForm.helpers.ts
+++ b/components/escrow/createEscrowForm.helpers.ts
@@ -78,6 +78,13 @@ export function hasExactShareAllocation(
   return Math.abs(sumRoommateShares(roommates) - total) <= AMOUNT_TOLERANCE;
 }
 
+export function formatFeeEstimate(feeXlm: string | null | undefined): string {
+  if (!feeXlm) {
+    return "Fee unavailable";
+  }
+  return `Estimated network fee: ~${feeXlm} XLM`;
+}
+
 export function validateEscrowStep(
   step: number,
   draft: EscrowFormDraft

--- a/lib/stellar/queries.test.ts
+++ b/lib/stellar/queries.test.ts
@@ -9,6 +9,7 @@ import {
   getBalance,
   getTotalFunded,
   isFullyFunded,
+  getFeeStats,
   ContractQueryError,
   type QueryContext,
   type SorobanQueryClient,
@@ -231,6 +232,86 @@ test("throws ContractQueryError when retval cannot be parsed as bool", async () 
       assert.match(err.message, /Cannot parse bool/);
       return true;
     }
+  );
+});
+
+// ─── getFeeStats ──────────────────────────────────────────────────────────────
+
+function makeFetchStub(
+  impl: (url: string) => {
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+  }
+) {
+  const calls: string[] = [];
+  const fetchImpl = async (url: string) => {
+    calls.push(url);
+    return impl(url);
+  };
+  return { fetchImpl, calls };
+}
+
+test("getFeeStats returns base fee in stroops and XLM for a valid response", async () => {
+  const { fetchImpl, calls } = makeFetchStub(() => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ last_ledger_base_fee: "100" }),
+  }));
+
+  const stats = await getFeeStats("testnet", fetchImpl);
+
+  assert.equal(stats.baseFeeStroops, "100");
+  assert.equal(stats.baseFeeXlm, "0.00001");
+  assert.equal(calls[0], "https://horizon-testnet.stellar.org/fee_stats");
+});
+
+test("getFeeStats hits the mainnet Horizon URL when network=mainnet", async () => {
+  const { fetchImpl, calls } = makeFetchStub(() => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ last_ledger_base_fee: "100" }),
+  }));
+
+  await getFeeStats("mainnet", fetchImpl);
+
+  assert.equal(calls[0], "https://horizon.stellar.org/fee_stats");
+});
+
+test("getFeeStats converts larger stroop values to XLM correctly", async () => {
+  const { fetchImpl } = makeFetchStub(() => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ last_ledger_base_fee: "12345678" }),
+  }));
+
+  const stats = await getFeeStats("testnet", fetchImpl);
+  assert.equal(stats.baseFeeXlm, "1.2345678");
+});
+
+test("getFeeStats throws when Horizon returns a non-ok status", async () => {
+  const { fetchImpl } = makeFetchStub(() => ({
+    ok: false,
+    status: 503,
+    json: async () => ({}),
+  }));
+
+  await assert.rejects(
+    () => getFeeStats("testnet", fetchImpl),
+    /fee_stats request failed: 503/
+  );
+});
+
+test("getFeeStats throws when last_ledger_base_fee is missing", async () => {
+  const { fetchImpl } = makeFetchStub(() => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ ledger_capacity_usage: "0.1" }),
+  }));
+
+  await assert.rejects(
+    () => getFeeStats("testnet", fetchImpl),
+    /Invalid fee_stats response/
   );
 });
 

--- a/lib/stellar/queries.ts
+++ b/lib/stellar/queries.ts
@@ -255,3 +255,70 @@ function parseBoolRetval(retval: unknown): boolean {
     `Cannot parse bool from retval: ${JSON.stringify(retval)}`
   );
 }
+
+// ─── Horizon: fee stats ───────────────────────────────────────────────────────
+
+export interface FeeStats {
+  /** Base fee in stroops (smallest unit on Stellar; 1 XLM = 10^7 stroops). */
+  baseFeeStroops: string;
+  /** Base fee in XLM as a trimmed decimal string (e.g. "0.00001"). */
+  baseFeeXlm: string;
+}
+
+const FEE_STATS_HORIZON_URLS = {
+  testnet: "https://horizon-testnet.stellar.org",
+  mainnet: "https://horizon.stellar.org",
+} as const;
+
+export type FeeStatsNetwork = keyof typeof FEE_STATS_HORIZON_URLS;
+
+type FetchLike = (
+  input: string,
+  init?: { signal?: AbortSignal }
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+/**
+ * Fetches the current base network fee from Horizon `GET /fee_stats`.
+ * Used before submitting a transaction to show an estimated network fee.
+ *
+ * Throws on network failure, non-2xx response, or malformed payload so callers
+ * can decide how to present fallback UI (e.g. "Fee unavailable").
+ */
+export async function getFeeStats(
+  network: FeeStatsNetwork = "testnet",
+  fetchImpl: FetchLike = fetch as unknown as FetchLike,
+  options: { signal?: AbortSignal } = {}
+): Promise<FeeStats> {
+  const url = `${FEE_STATS_HORIZON_URLS[network]}/fee_stats`;
+
+  const response = await fetchImpl(url, { signal: options.signal });
+
+  if (!response.ok) {
+    throw new Error(`Horizon fee_stats request failed: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { last_ledger_base_fee?: unknown };
+  const raw = data.last_ledger_base_fee;
+  const stroops =
+    typeof raw === "string" ? raw : typeof raw === "number" ? String(raw) : "";
+
+  if (!/^\d+$/.test(stroops)) {
+    throw new Error(
+      "Invalid fee_stats response: missing or non-numeric last_ledger_base_fee"
+    );
+  }
+
+  return {
+    baseFeeStroops: stroops,
+    baseFeeXlm: stroopsToXlm(stroops),
+  };
+}
+
+function stroopsToXlm(stroops: string): string {
+  const STROOPS_PER_XLM = BigInt(10_000_000);
+  const value = BigInt(stroops);
+  const whole = value / STROOPS_PER_XLM;
+  const fraction = value % STROOPS_PER_XLM;
+  const fractionStr = fraction.toString().padStart(7, "0").replace(/0+$/, "");
+  return fractionStr.length > 0 ? `${whole}.${fractionStr}` : whole.toString();
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.pravatar.cc",
+      },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Adds `getFeeStats()` in `lib/stellar/queries.ts` that fetches the base fee from Horizon `GET /fee_stats` and returns both stroops and a trimmed XLM string.
- Wires the fetch into `CreateEscrowForm` when the user reaches the review step, rendering "Estimated network fee: ~X XLM" or falling back to "Fee unavailable" if the request fails — submission stays unblocked either way.
- Drive-by: whitelists `i.pravatar.cc` and `images.unsplash.com` in `next.config.js` so the home page stops 500-ing on `next/image` — unrelated to #499 but the app didn't boot without it.

Closes #499.

## Test plan
- [x] `npm test` — new unit tests cover `getFeeStats` (success, mainnet URL, stroops→XLM conversion, non-ok status, malformed payload) and `formatFeeEstimate` (fee rendered + fallback copy).
- [ ] Manual: load `/escrow/create`, fill steps 1–3, reach the review step, confirm the fee line renders with a value (or "Fee unavailable" when offline).