### PR TITLE
feat: add global toast notification system (Issue #43)

### DIFF
--- a/components/ui/app-shell.tsx
+++ b/components/ui/app-shell.tsx
@@ -3,6 +3,7 @@
 import { ThemeProvider } from "@/components/ui/theme-provider";
 import { DottedSurface } from "@/components/ui/dotted-surface";
 import { StellarProvider } from "@/context/StellarContext";
+import { ToastProvider } from "@/components/ui/toast-provider";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (
@@ -15,7 +16,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <DottedSurface />
       <div className="mesh-gradient" aria-hidden="true" />
       <StellarProvider>
-        <div className="relative z-10">{children}</div>
+        <ToastProvider>
+          <div className="relative z-10">{children}</div>
+        </ToastProvider>
       </StellarProvider>
     </ThemeProvider>
   );

--- a/components/ui/toast-provider.tsx
+++ b/components/ui/toast-provider.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { AnimatePresence } from "framer-motion";
+import { Toast, type ToastItem, type ToastVariant } from "./toast";
+
+interface ToastContextValue {
+  show: (message: string, variant: ToastVariant) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const baseId = useId();
+  const counterRef = useRef(0);
+
+  const show = useCallback((message: string, variant: ToastVariant) => {
+    const id = `${baseId}-${Date.now()}-${counterRef.current++}`;
+    setToasts((prev) => [...prev, { id, message, variant }]);
+  }, [baseId]);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      <div
+        aria-label="Notifications"
+        className="fixed bottom-6 right-6 z-[200] flex flex-col-reverse gap-3 items-end"
+      >
+        <AnimatePresence mode="popLayout">
+          {toasts.map((toast) => (
+            <Toast key={toast.id} toast={toast} onDismiss={dismiss} />
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToastContext(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToastContext must be used within ToastProvider");
+  return ctx;
+}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion } from "framer-motion";
+import { CheckCircle, XCircle, Info, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type ToastVariant = "success" | "error" | "info";
+
+export interface ToastItem {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastProps {
+  toast: ToastItem;
+  onDismiss: (id: string) => void;
+}
+
+const VARIANT_STYLES: Record<ToastVariant, { container: string; icon: React.ReactNode }> = {
+  success: {
+    container: "border-accent-500/30 bg-accent-500/10 text-accent-300",
+    icon: <CheckCircle size={18} className="text-accent-400 shrink-0" />,
+  },
+  error: {
+    container: "border-red-500/30 bg-red-500/10 text-red-300",
+    icon: <XCircle size={18} className="text-red-400 shrink-0" />,
+  },
+  info: {
+    container: "border-brand-500/30 bg-brand-500/10 text-brand-300",
+    icon: <Info size={18} className="text-brand-400 shrink-0" />,
+  },
+};
+
+const AUTO_DISMISS_MS = 4000;
+
+export function Toast({ toast, onDismiss }: ToastProps) {
+  const { container, icon } = VARIANT_STYLES[toast.variant];
+
+  useEffect(() => {
+    const timer = setTimeout(() => onDismiss(toast.id), AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [toast.id, onDismiss]);
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, x: 80, scale: 0.95 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={{ opacity: 0, x: 80, scale: 0.95 }}
+      transition={{ type: "spring", stiffness: 300, damping: 25 }}
+      className={cn(
+        "flex items-start gap-3 rounded-2xl border px-4 py-3 shadow-xl backdrop-blur-md w-80 max-w-[calc(100vw-2rem)]",
+        container
+      )}
+      role="alert"
+      aria-live="polite"
+    >
+      {icon}
+      <p className="flex-1 text-sm leading-snug">{toast.message}</p>
+      <button
+        onClick={() => onDismiss(toast.id)}
+        className="ml-1 rounded-full p-0.5 opacity-60 hover:opacity-100 transition-opacity"
+        aria-label="Dismiss notification"
+      >
+        <X size={14} />
+      </button>
+    </motion.div>
+  );
+}

--- a/hooks/useToast.test.ts
+++ b/hooks/useToast.test.ts
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Unit-test the toast data model independently of React rendering.
+// Full render/dismiss behaviour is covered by manual browser testing per the acceptance criteria.
+
+test("toast variants are the expected string literals", () => {
+  const variants = ["success", "error", "info"] as const;
+  assert.equal(variants.length, 3);
+  assert.ok(variants.includes("success"));
+  assert.ok(variants.includes("error"));
+  assert.ok(variants.includes("info"));
+});
+
+test("multiple toasts have unique ids", () => {
+  // Simulate the id-generation strategy used in ToastProvider
+  const makeId = (base: string, ts: number, i: number) => `${base}-${ts}-${i}`;
+  const base = "r0";
+  const now = Date.now();
+  const ids = [0, 1, 2].map((i) => makeId(base, now, i));
+  const unique = new Set(ids);
+  assert.equal(unique.size, 3, "all three ids must be unique");
+});
+
+test("toasts stack: adding three toasts produces three entries", () => {
+  type ToastItem = { id: string; message: string; variant: string };
+  const toasts: ToastItem[] = [];
+  const add = (msg: string, variant: string, i: number) =>
+    toasts.push({ id: `id-${i}`, message: msg, variant });
+
+  add("Payment sent", "success", 0);
+  add("Network error", "error", 1);
+  add("Testnet mode active", "info", 2);
+
+  assert.equal(toasts.length, 3);
+  assert.equal(toasts[0].variant, "success");
+  assert.equal(toasts[1].variant, "error");
+  assert.equal(toasts[2].variant, "info");
+});
+
+test("dismiss removes only the targeted toast", () => {
+  type ToastItem = { id: string; message: string };
+  let toasts: ToastItem[] = [
+    { id: "a", message: "first" },
+    { id: "b", message: "second" },
+    { id: "c", message: "third" },
+  ];
+
+  const dismiss = (id: string) => {
+    toasts = toasts.filter((t) => t.id !== id);
+  };
+
+  dismiss("b");
+  assert.equal(toasts.length, 2);
+  assert.ok(toasts.every((t) => t.id !== "b"));
+  assert.ok(toasts.some((t) => t.id === "a"));
+  assert.ok(toasts.some((t) => t.id === "c"));
+});

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useCallback } from "react";
+import { useToastContext } from "@/components/ui/toast-provider";
+
+export function useToast() {
+  const { show } = useToastContext();
+
+  const success = useCallback(
+    (message: string) => show(message, "success"),
+    [show]
+  );
+  const error = useCallback(
+    (message: string) => show(message, "error"),
+    [show]
+  );
+  const info = useCallback(
+    (message: string) => show(message, "info"),
+    [show]
+  );
+
+  return { success, error, info };
+}


### PR DESCRIPTION
  closes: #462 
  
  **Summary**
   - Implements global toast/snackbar system with `success`, `error`, and `info` variants                       
   - Toasts slide in from bottom-right via framer-motion, auto-dismiss after 4s, and support manual dismiss     
   via X button
   - Exposes `useToast()` hook callable from anywhere in the app
   
   