### PR TITLE
feat(connect): post-connect onboarding card (#486)

### DIFF
--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -21,6 +21,8 @@ import Link from "next/link";
 import { useStellar } from "@/context/StellarContext";
 import { PayEasyLogo } from "@/components/ui/payeasy-logo";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { OnboardingCard } from "@/components/ui/onboarding-card";
+import { isOnboarded, markOnboarded } from "@/components/ui/onboarding-card.helpers";
 import FundTestnetButton from "@/components/wallet/FundTestnetButton";
 
 const FEATURES = [
@@ -58,16 +60,25 @@ export default function ConnectWalletPage() {
   const [step, setStep] = useState<Step>("intro");
   const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
   const [errorExpanded, setErrorExpanded] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   useEffect(() => {
     if (isConnected && publicKey) {
       setStep("connected");
+      if (!isOnboarded()) {
+        setShowOnboarding(true);
+      }
     } else if (isConnecting) {
       setStep("connecting");
     } else {
       setStep("intro");
     }
   }, [isConnected, isConnecting, publicKey]);
+
+  const handleDismissOnboarding = () => {
+    markOnboarded();
+    setShowOnboarding(false);
+  };
 
   const handleConnect = async () => {
     setStep("connecting");
@@ -392,6 +403,13 @@ export default function ConnectWalletPage() {
               <div className="w-full mt-4">
                 <FundTestnetButton publicKey={publicKey} />
               </div>
+
+              {/* First-time onboarding prompt */}
+              {showOnboarding && (
+                <div className="w-full mt-4">
+                  <OnboardingCard onDismiss={handleDismissOnboarding} />
+                </div>
+              )}
 
               {/* Action buttons */}
               <div className="w-full grid grid-cols-2 gap-3 mt-6">

--- a/components/ui/onboarding-card.helpers.ts
+++ b/components/ui/onboarding-card.helpers.ts
@@ -1,0 +1,24 @@
+export const ONBOARDING_STORAGE_KEY = "payeasy_onboarded";
+
+export interface OnboardingStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function resolveStorage(storage?: OnboardingStorage): OnboardingStorage | null {
+  if (storage) return storage;
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+export function isOnboarded(storage?: OnboardingStorage): boolean {
+  const target = resolveStorage(storage);
+  if (!target) return false;
+  return target.getItem(ONBOARDING_STORAGE_KEY) === "1";
+}
+
+export function markOnboarded(storage?: OnboardingStorage): void {
+  const target = resolveStorage(storage);
+  if (!target) return;
+  target.setItem(ONBOARDING_STORAGE_KEY, "1");
+}

--- a/components/ui/onboarding-card.test.ts
+++ b/components/ui/onboarding-card.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ONBOARDING_STORAGE_KEY,
+  isOnboarded,
+  markOnboarded,
+  type OnboardingStorage,
+} from "./onboarding-card.helpers.ts";
+
+function makeMemoryStorage(seed: Record<string, string> = {}): OnboardingStorage & {
+  dump: () => Record<string, string>;
+} {
+  const store: Record<string, string> = { ...seed };
+  return {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key, value) {
+      store[key] = value;
+    },
+    dump() {
+      return { ...store };
+    },
+  };
+}
+
+test("isOnboarded returns false for a fresh storage (first connect)", () => {
+  const storage = makeMemoryStorage();
+  assert.equal(isOnboarded(storage), false);
+});
+
+test("isOnboarded returns true once markOnboarded has been called", () => {
+  const storage = makeMemoryStorage();
+  markOnboarded(storage);
+  assert.equal(isOnboarded(storage), true);
+});
+
+test("markOnboarded writes the expected key/value into storage", () => {
+  const storage = makeMemoryStorage();
+  markOnboarded(storage);
+  assert.equal(storage.dump()[ONBOARDING_STORAGE_KEY], "1");
+});
+
+test("isOnboarded only accepts the '1' flag value (ignores stale/unexpected values)", () => {
+  const stale = makeMemoryStorage({ [ONBOARDING_STORAGE_KEY]: "true" });
+  assert.equal(isOnboarded(stale), false);
+});
+
+test("isOnboarded returns false when no storage is available (SSR)", () => {
+  // No storage argument and no `window` in the node test runner — SSR-safe path.
+  assert.equal(isOnboarded(), false);
+});

--- a/components/ui/onboarding-card.tsx
+++ b/components/ui/onboarding-card.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Check, Sparkles, Wallet, FilePlus, History } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+
+export interface OnboardingStep {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  title: string;
+  description: string;
+}
+
+export const DEFAULT_ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    icon: Wallet,
+    title: "Fund your testnet wallet",
+    description: "Use the Friendbot button to load test XLM and explore without risk.",
+  },
+  {
+    icon: FilePlus,
+    title: "Create your first escrow",
+    description: "Split rent with roommates through a trustless Stellar contract.",
+  },
+  {
+    icon: History,
+    title: "Track agreements in history",
+    description: "Review funding progress, contributions, and releases any time.",
+  },
+];
+
+interface OnboardingCardProps {
+  onDismiss: () => void;
+  steps?: OnboardingStep[];
+}
+
+export function OnboardingCard({
+  onDismiss,
+  steps = DEFAULT_ONBOARDING_STEPS,
+}: OnboardingCardProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -12 }}
+      transition={{ duration: 0.35 }}
+      role="dialog"
+      aria-labelledby="onboarding-card-title"
+      data-testid="onboarding-card"
+      className="w-full glass-card p-5 space-y-5 hover:!transform-none"
+    >
+      <div className="flex items-start gap-3">
+        <div className="p-2 rounded-lg bg-brand-500/10 border border-brand-500/20">
+          <Sparkles className="w-5 h-5 text-brand-400" />
+        </div>
+        <div>
+          <h3
+            id="onboarding-card-title"
+            className="text-white font-semibold text-sm mb-1 font-display"
+          >
+            Welcome to PayEasy
+          </h3>
+          <p className="text-dark-500 text-sm leading-relaxed">
+            You&apos;re connected. Here are three things to try next.
+          </p>
+        </div>
+      </div>
+
+      <ol className="space-y-3">
+        {steps.map((step, index) => (
+          <li
+            key={step.title}
+            className="flex items-start gap-3 rounded-xl border border-white/5 bg-white/[0.02] p-3"
+          >
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-500/10 border border-brand-500/20 shrink-0">
+              <step.icon className="w-4 h-4 text-brand-400" />
+            </div>
+            <div className="flex-1">
+              <p className="text-white text-sm font-semibold font-display">
+                <span className="text-dark-500 mr-2">{index + 1}.</span>
+                {step.title}
+              </p>
+              <p className="text-dark-500 text-xs mt-0.5 leading-relaxed">
+                {step.description}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="btn-primary w-full !justify-center !rounded-xl !py-3 text-sm"
+      >
+        <Check size={16} />
+        Got it
+      </button>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `OnboardingCard` component in `components/ui/onboarding-card.tsx` with three default next-step hints (fund testnet, create escrow, view history) and a "Got it" dismiss button.
- `isOnboarded()` / `markOnboarded()` helpers around the `payeasy_onboarded` localStorage flag, with an injectable `Storage` shape so the logic is unit-testable under the node:test runner and safe under SSR.
- `app/connect/page.tsx` reveals the card only on a first successful connection; dismissing it sets the flag so later connections skip it.

Closes #486.

## Test plan
- [x] `npm test` — 5 new unit tests cover fresh storage, post-mark state, key/value written, stale-value rejection, and the SSR fallback path.
- [ ] Manual: clear `localStorage`, visit `/connect`, connect with Freighter → onboarding card appears. Click **Got it** → card hides, `payeasy_onboarded=1` in storage. Disconnect + reconnect → no card.