### PR TITLE
feat(escrow): deadline calendar picker with tomorrow minimum (#496)

### DIFF
--- a/components/escrow/CreateEscrowForm.tsx
+++ b/components/escrow/CreateEscrowForm.tsx
@@ -12,6 +12,8 @@ import { useFormDraft } from "@/hooks/useFormDraft";
 import { useBeforeUnload } from "@/hooks/useBeforeUnload";
 import RoommateInput from "./RoommateInput";
 import { FieldError, fieldBorderClass } from "@/components/ui/field-error";
+import { DateInput } from "@/components/ui/date-input";
+import { isDateOnOrAfterTomorrow } from "@/components/ui/date-input.helpers";
 import {
   calculateRemainingAmount,
   formatFeeEstimate,
@@ -178,7 +180,11 @@ export default function CreateEscrowForm({
       if (!draft.tokenId.trim()) errs.tokenId = "Required";
     }
     if (step === 2 || step === 4) {
-      if (!toLedgerTimestamp(draft.deadlineDate)) errs.deadlineDate = "Set a valid deadline date.";
+      if (!toLedgerTimestamp(draft.deadlineDate)) {
+        errs.deadlineDate = "Set a valid deadline date.";
+      } else if (!isDateOnOrAfterTomorrow(draft.deadlineDate)) {
+        errs.deadlineDate = "Deadline must be tomorrow or later.";
+      }
     }
     return errs;
   }
@@ -495,24 +501,20 @@ export default function CreateEscrowForm({
         ) : null}
 
         {step === 2 ? (
-          <div className="space-y-1">
+          <div className="space-y-2">
             <label htmlFor="deadline-date" className="block text-sm text-dark-400">
               Escrow Deadline
             </label>
-            <input
+            <DateInput
               id="deadline-date"
-              type="date"
               value={draft.deadlineDate}
-              onChange={(event) => {
-                setDraft((current) => ({ ...current, deadlineDate: event.target.value }));
-                if (event.target.value) clearFieldError("deadlineDate");
+              onChange={(next) => {
+                setDraft((current) => ({ ...current, deadlineDate: next }));
+                if (next) clearFieldError("deadlineDate");
               }}
-              aria-describedby={fieldErrors.deadlineDate ? "deadline-date-error" : undefined}
-              aria-invalid={!!fieldErrors.deadlineDate}
-              className={`w-full rounded-xl border bg-white/5 px-4 py-3 text-dark-100 focus:outline-none transition-colors ${fieldBorderClass(fieldErrors.deadlineDate, !!draft.deadlineDate)}`}
+              error={fieldErrors.deadlineDate}
             />
-            <FieldError id="deadline-date-error" message={fieldErrors.deadlineDate} />
-            <p className="text-sm text-dark-500">
+            <p className="text-xs text-dark-500">
               Ledger timestamp: {deadlineLedgerTimestamp ?? "-"}
             </p>
           </div>

--- a/components/escrow/createEscrowForm.helpers.ts
+++ b/components/escrow/createEscrowForm.helpers.ts
@@ -1,4 +1,5 @@
 import type { SupportedToken } from "../../lib/stellar/config.ts";
+import { isDateOnOrAfterTomorrow } from "../ui/date-input.helpers.ts";
 
 export const MIN_ESCROW_STEP = 1;
 export const MAX_ESCROW_STEP = 4;
@@ -108,6 +109,8 @@ export function validateEscrowStep(
     const ledgerTimestamp = toLedgerTimestamp(draft.deadlineDate);
     if (!ledgerTimestamp) {
       errors.push("Set a valid deadline date.");
+    } else if (!isDateOnOrAfterTomorrow(draft.deadlineDate)) {
+      errors.push("Deadline must be tomorrow or later.");
     }
   }
 

--- a/components/ui/date-input.helpers.ts
+++ b/components/ui/date-input.helpers.ts
@@ -1,0 +1,72 @@
+const DISPLAY_MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+function toIso(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Returns the ISO "YYYY-MM-DD" representation of the UTC day after `now`.
+ * Used as the `min` attribute on the deadline picker so today is not
+ * selectable.
+ */
+export function getTomorrowIso(now: Date = new Date()): string {
+  const tomorrow = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1)
+  );
+  return toIso(tomorrow);
+}
+
+/**
+ * True when `dateValue` is a valid ISO date string that falls on or after
+ * tomorrow (UTC). Today and any earlier date — plus blanks / malformed
+ * values — return false.
+ */
+export function isDateOnOrAfterTomorrow(
+  dateValue: string,
+  now: Date = new Date()
+): boolean {
+  if (!dateValue) return false;
+
+  const parsed = new Date(`${dateValue}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return false;
+
+  const tomorrowStart = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1
+  );
+  return parsed.getTime() >= tomorrowStart;
+}
+
+/**
+ * Formats an ISO "YYYY-MM-DD" date as "MMM DD, YYYY".
+ * Returns an empty string for blank or unparseable input so callers can
+ * render nothing without branching.
+ */
+export function formatDeadlineDisplay(dateValue: string): string {
+  if (!dateValue) return "";
+
+  const parsed = new Date(`${dateValue}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return "";
+
+  const month = DISPLAY_MONTHS[parsed.getUTCMonth()];
+  const day = String(parsed.getUTCDate()).padStart(2, "0");
+  const year = parsed.getUTCFullYear();
+  return `${month} ${day}, ${year}`;
+}

--- a/components/ui/date-input.test.ts
+++ b/components/ui/date-input.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatDeadlineDisplay,
+  getTomorrowIso,
+  isDateOnOrAfterTomorrow,
+} from "./date-input.helpers.ts";
+
+const NOW = new Date("2026-04-24T12:34:56.000Z");
+
+test("getTomorrowIso returns the UTC day after `now` as YYYY-MM-DD", () => {
+  assert.equal(getTomorrowIso(NOW), "2026-04-25");
+});
+
+test("getTomorrowIso rolls over month boundaries", () => {
+  assert.equal(getTomorrowIso(new Date("2026-04-30T23:00:00.000Z")), "2026-05-01");
+});
+
+test("isDateOnOrAfterTomorrow rejects today", () => {
+  assert.equal(isDateOnOrAfterTomorrow("2026-04-24", NOW), false);
+});
+
+test("isDateOnOrAfterTomorrow accepts tomorrow and beyond", () => {
+  assert.equal(isDateOnOrAfterTomorrow("2026-04-25", NOW), true);
+  assert.equal(isDateOnOrAfterTomorrow("2027-01-01", NOW), true);
+});
+
+test("isDateOnOrAfterTomorrow rejects blanks and malformed dates", () => {
+  assert.equal(isDateOnOrAfterTomorrow("", NOW), false);
+  assert.equal(isDateOnOrAfterTomorrow("not-a-date", NOW), false);
+});
+
+test("formatDeadlineDisplay renders MMM DD, YYYY", () => {
+  assert.equal(formatDeadlineDisplay("2026-04-25"), "Apr 25, 2026");
+  assert.equal(formatDeadlineDisplay("2026-12-01"), "Dec 01, 2026");
+});
+
+test("formatDeadlineDisplay returns empty string for blank or invalid input", () => {
+  assert.equal(formatDeadlineDisplay(""), "");
+  assert.equal(formatDeadlineDisplay("not-a-date"), "");
+});
+
+test("selecting a valid date exposes a formatted string alongside the ISO value stored in state", () => {
+  // Simulates the form wiring: the input fires onChange with an ISO string,
+  // and the UI surfaces the "MMM DD, YYYY" formatted version.
+  const iso = "2026-05-10";
+  const formatted = formatDeadlineDisplay(iso);
+
+  assert.equal(iso, "2026-05-10");
+  assert.equal(formatted, "May 10, 2026");
+  assert.equal(isDateOnOrAfterTomorrow(iso, NOW), true);
+});

--- a/components/ui/date-input.tsx
+++ b/components/ui/date-input.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useMemo } from "react";
+import { CalendarDays } from "lucide-react";
+import { FieldError, fieldBorderClass } from "@/components/ui/field-error";
+import {
+  formatDeadlineDisplay,
+  getTomorrowIso,
+} from "./date-input.helpers";
+
+interface DateInputProps {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  /** Optional override for the minimum selectable date (ISO "YYYY-MM-DD"). Defaults to tomorrow. */
+  min?: string;
+  error?: string;
+  "aria-describedby"?: string;
+}
+
+export function DateInput({
+  id,
+  value,
+  onChange,
+  min,
+  error,
+  "aria-describedby": ariaDescribedBy,
+}: DateInputProps) {
+  const minIso = useMemo(() => min ?? getTomorrowIso(), [min]);
+  const formatted = formatDeadlineDisplay(value);
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [errorId, ariaDescribedBy].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div className="space-y-2">
+      <div
+        className={`relative flex items-center rounded-xl border bg-white/5 transition-colors focus-within:border-brand-400 ${fieldBorderClass(error, !!value)}`}
+      >
+        <span
+          className="pointer-events-none flex items-center justify-center pl-3 text-dark-500"
+          aria-hidden="true"
+        >
+          <CalendarDays size={18} />
+        </span>
+        <input
+          id={id}
+          type="date"
+          value={value}
+          min={minIso}
+          onChange={(event) => onChange(event.target.value)}
+          aria-describedby={describedBy}
+          aria-invalid={!!error}
+          data-testid="deadline-date-input"
+          className="w-full bg-transparent px-3 py-3 text-dark-100 placeholder:text-dark-600 focus:outline-none [color-scheme:dark]"
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <span
+          data-testid="deadline-formatted"
+          className={formatted ? "text-brand-200" : "text-dark-500"}
+        >
+          {formatted || "No date selected"}
+        </span>
+        <span className="text-xs text-dark-500">
+          Earliest: {formatDeadlineDisplay(minIso)}
+        </span>
+      </div>
+
+      <FieldError id={errorId} message={error} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `components/ui/date-input.tsx` wraps the native `<input type="date">` in the dark-glass design system (calendar icon, `color-scheme: dark`, focus ring matching the rest of the form) and renders the selected date as "MMM DD, YYYY" beside the input, plus an "Earliest: …" hint.
- Helpers in `components/ui/date-input.helpers.ts` — `getTomorrowIso`, `isDateOnOrAfterTomorrow`, `formatDeadlineDisplay` — are UTC-based (consistent with `toLedgerTimestamp`) and accept an injectable `now` so the today/tomorrow boundary is deterministic under `node:test`.
- Step 2 of `CreateEscrowForm` uses the new `DateInput`; both `buildFieldErrors` and `validateEscrowStep` reject any deadline that isn't tomorrow or later, so Continue on step 2 and Create Escrow on step 4 can't accept today.

Closes #496.

## Test plan
- [x] `npm test` — 8 new unit tests cover the tomorrow ISO (including month rollover), today/tomorrow boundary accept/reject, blank + malformed input, MMM DD, YYYY formatting, and an integration-style check asserting the formatted string alongside the ISO value in state.
- [ ] Manual: on `/escrow/create` step 2, try to pick today (should be unselectable via the browser's `min` attribute, and Continue rejects with "Deadline must be tomorrow or later."). Pick tomorrow or later → "MMM DD, YYYY" appears next to the input, Continue proceeds, and step 4 review shows the ledger timestamp.