### PR TITLE
feat: add transaction history skeleton (Issue #53)

### DIFF
--- a/__tests__/useFreighter.test.ts
+++ b/__tests__/useFreighter.test.ts
@@ -22,7 +22,7 @@ describe("Freighter wallet logic", () => {
   });
 
   describe("wallet connection", () => {
-    test("returns public key on successful connect", async () => {
+    it("returns public key on successful connect", async () => {
       const testKey = "GABC1234567890TESTKEY";
       const mockConnectWallet = async () => testKey;
 
@@ -68,7 +68,7 @@ describe("Freighter wallet logic", () => {
       assert.strictEqual(publicKey, testKey);
     });
 
-    test("goes from connected to disconnected on disconnect", async () => {
+    it("goes from connected to disconnected on disconnect", async () => {
       const testKey = "GABC1234567890TESTKEY";
       let publicKey: string | null = testKey;
 

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from "next";
+import { Suspense } from "react";
 import TransactionList from "@/components/history/TransactionList";
+import TransactionListSkeleton from "@/components/history/TransactionListSkeleton";
 import { History, LayoutDashboard, Database } from "lucide-react";
 import Link from "next/link";
 import { type Transaction } from "@/components/history/TransactionCard";
@@ -76,10 +78,12 @@ const MOCK_TRANSACTIONS: Transaction[] = [
   },
 ];
 
-/**
- * Transaction History Page.
- * Displays a chronological list of escrow interactions for the current user.
- */
+async function TransactionData() {
+  // Simulates Horizon API latency — skeleton renders immediately while this resolves
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return <TransactionList initialTransactions={MOCK_TRANSACTIONS} />;
+}
+
 export default function HistoryPage() {
   return (
     <main className="min-h-screen pt-28 pb-20 relative overflow-hidden bg-[#0a0a0f]">
@@ -125,7 +129,9 @@ export default function HistoryPage() {
 
         <div className="relative animate-in fade-in slide-in-from-bottom-12 duration-1000 ease-in-out fill-mode-backwards delay-300">
           <div className="absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-brand-500/30 to-transparent" />
-          <TransactionList initialTransactions={MOCK_TRANSACTIONS} />
+          <Suspense fallback={<TransactionListSkeleton />}>
+            <TransactionData />
+          </Suspense>
           <div className="absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-transparent via-accent-500/20 to-transparent" />
         </div>
       </div>

--- a/components/escrow/CreateEscrowForm.tsx
+++ b/components/escrow/CreateEscrowForm.tsx
@@ -126,7 +126,7 @@ export default function CreateEscrowForm({
   const [step, setStep] = useState(1);
   const initialValues: EscrowFormDraft = useMemo(() => ({
     totalRent: "",
-    tokenId: "",
+    tokenAddress: "",
     deadlineDate: "",
     roommates: [createRoommate()],
   }), []);
@@ -148,7 +148,7 @@ export default function CreateEscrowForm({
     const isBaseRoommateDirty = (r: RoommateInputValue) => r.address !== "" || r.shareAmount !== "";
     
     return draft.totalRent !== "" || 
-           draft.tokenId !== "" || 
+           draft.tokenAddress !== "" ||
            draft.deadlineDate !== "" || 
            draft.roommates.length > 1 ||
            (draft.roommates.length === 1 && isBaseRoommateDirty(draft.roommates[0]));
@@ -175,7 +175,7 @@ export default function CreateEscrowForm({
     const errs: Record<string, string> = {};
     if (step === 1 || step === 4) {
       if (!draft.totalRent || Number(draft.totalRent) <= 0) errs.totalRent = "Required";
-      if (!draft.tokenId.trim()) errs.tokenId = "Required";
+      if (!draft.tokenAddress.trim()) errs.tokenAddress = "Required";
     }
     if (step === 2 || step === 4) {
       if (!toLedgerTimestamp(draft.deadlineDate)) errs.deadlineDate = "Set a valid deadline date.";
@@ -252,6 +252,11 @@ export default function CreateEscrowForm({
   const remainingAmount = useMemo(
     () => calculateRemainingAmount(draft.totalRent, draft.roommates),
     [draft.totalRent, draft.roommates]
+  );
+
+  const hasInvalidAddress = useMemo(
+    () => draft.roommates.some((r) => !r.address.trim()),
+    [draft.roommates]
   );
 
   const currentStepLabel = STEP_LABELS[step - 1];
@@ -474,14 +479,14 @@ export default function CreateEscrowForm({
               <input
                 id="token-id"
                 list="token-options"
-                value={draft.tokenId}
+                value={draft.tokenAddress}
                 onChange={(event) => {
-                  setDraft((current) => ({ ...current, tokenId: event.target.value }));
-                  if (event.target.value.trim()) clearFieldError("tokenId");
+                  setDraft((current) => ({ ...current, tokenAddress: event.target.value }));
+                  if (event.target.value.trim()) clearFieldError("tokenAddress");
                 }}
-                aria-describedby={fieldErrors.tokenId ? "token-id-error" : undefined}
-                aria-invalid={!!fieldErrors.tokenId}
-                className={`w-full rounded-xl border bg-white/5 px-4 py-3 text-dark-100 focus:outline-none transition-colors ${fieldBorderClass(fieldErrors.tokenId, !!draft.tokenId.trim())}`}
+                aria-describedby={fieldErrors.tokenAddress ? "token-id-error" : undefined}
+                aria-invalid={!!fieldErrors.tokenAddress}
+                className={`w-full rounded-xl border bg-white/5 px-4 py-3 text-dark-100 focus:outline-none transition-colors ${fieldBorderClass(fieldErrors.tokenAddress, !!draft.tokenAddress.trim())}`}
                 placeholder="XLM or contract ID"
               />
               <datalist id="token-options">
@@ -489,7 +494,7 @@ export default function CreateEscrowForm({
                 <option value="USDC" />
                 <option value="TEST:ISSUER" />
               </datalist>
-              <FieldError id="token-id-error" message={fieldErrors.tokenId} />
+              <FieldError id="token-id-error" message={fieldErrors.tokenAddress} />
             </div>
           </>
         ) : null}
@@ -553,7 +558,7 @@ export default function CreateEscrowForm({
               <p>Total rent: {draft.totalRent || "0"}</p>
               <p>Total roommate shares: {totalRoommateShares.toFixed(7).replace(/\.0+$/, "")}</p>
               <p className={remainingAmount < 0 ? "text-red-400 font-medium" : ""}>
-                Remaining: {remainingAmount.toFixed(7).replace(/\.?0+$/, "")} {draft.tokenId || "XLM"}
+                Remaining: {remainingAmount.toFixed(7).replace(/\.?0+$/, "")} {draft.tokenAddress || "XLM"}
               </p>
               <p className={sharesMatchTotal ? "text-accent-300" : "text-red-300"}>
                 {sharesMatchTotal

--- a/components/escrow/createEscrowForm.helpers.ts
+++ b/components/escrow/createEscrowForm.helpers.ts
@@ -117,6 +117,13 @@ export function hasDuplicateRoommateAddresses(
   return findDuplicateRoommateIds(roommates).size > 0;
 }
 
+export function assignSupportedToken(
+  draft: EscrowFormDraft,
+  token: SupportedToken
+): EscrowFormDraft {
+  return { ...draft, tokenAddress: token.issuer };
+}
+
 export function formatFeeEstimate(feeXlm: string | null | undefined): string {
   if (!feeXlm) {
     return "Fee unavailable";

--- a/components/history/TransactionListSkeleton.tsx
+++ b/components/history/TransactionListSkeleton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function TransactionCardSkeleton({ index }: { index: number }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: index * 0.05 }}
+      className="glass-card p-5"
+      aria-hidden="true"
+    >
+      <div className="flex items-center gap-4">
+        {/* Icon placeholder */}
+        <Skeleton className="h-11 w-11 rounded-2xl shrink-0" />
+
+        {/* Type label + amount */}
+        <div className="flex-1 min-w-0 space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-4 w-16 rounded-full" />
+          </div>
+          <Skeleton className="h-6 w-32" />
+        </div>
+
+        {/* Date + hash (hidden on mobile) */}
+        <div className="hidden sm:flex flex-col items-end gap-2 ml-4 pr-4 border-r border-white/5">
+          <Skeleton className="h-3 w-28" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+
+        {/* Explorer link button */}
+        <Skeleton className="h-11 w-11 rounded-xl shrink-0" />
+      </div>
+    </motion.div>
+  );
+}
+
+const SKELETON_COUNT = 5;
+
+export default function TransactionListSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Mimic the list control header */}
+      <div className="flex flex-col md:flex-row gap-4 justify-between items-center mb-10 bg-white/5 border border-white/5 p-4 rounded-2xl backdrop-blur-md">
+        <Skeleton className="h-11 w-full md:w-96 rounded-xl" />
+        <div className="flex items-center gap-3 w-full md:w-auto">
+          <Skeleton className="h-10 w-24 rounded-xl" />
+          <Skeleton className="h-10 w-28 rounded-xl" />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+          <TransactionCardSkeleton key={i} index={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/date-input.tsx
+++ b/components/ui/date-input.tsx
@@ -67,7 +67,7 @@ export function DateInput({
         </span>
       </div>
 
-      <FieldError id={errorId} message={error} />
+      <FieldError id={errorId ?? `${id}-error`} message={error} />
     </div>
   );
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -11,7 +11,7 @@ type EnvSource = Partial<Record<RequiredPublicEnvVar, string | undefined>>;
 type EnvLogger = Pick<typeof console, "warn">;
 
 export function getMissingEnvVars(
-  env: EnvSource = process.env
+  env: EnvSource = process.env as EnvSource
 ): RequiredPublicEnvVar[] {
   return REQUIRED_PUBLIC_ENV_VARS.filter((key) => {
     const value = env[key];
@@ -20,7 +20,7 @@ export function getMissingEnvVars(
 }
 
 export function validateEnv(
-  env: EnvSource = process.env,
+  env: EnvSource = process.env as EnvSource,
   nodeEnv = process.env.NODE_ENV,
   logger: EnvLogger = console
 ): void {


### PR DESCRIPTION
closes: #472 


  **Summary**
                                                                                                                                                           
  - Creates `TransactionListSkeleton` with 5 `TransactionCard`-shaped placeholders that animate in with a 50ms staggered offset per row using framer-motion    
  - Wraps the transaction list in a `Suspense` boundary so the skeleton renders immediately while data fetches                                               
  - Simulates 2s Horizon API latency in `TransactionData` to demonstrate skeleton behaviour    