### PR TITLE
feat(wallet): detect outdated Freighter version and warn users (#519)

### DIFF
--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -25,7 +25,7 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { OnboardingCard } from "@/components/ui/onboarding-card";
 import { isOnboarded, markOnboarded } from "@/components/ui/onboarding-card.helpers";
 import FundTestnetButton from "@/components/wallet/FundTestnetButton";
-import { getFreighterNetwork } from "@/lib/stellar/wallet";
+import { getFreighterNetwork, isFreighterVersionSupported } from "@/lib/stellar/wallet";
 import { getCurrentNetwork } from "@/lib/stellar/config";
 
 const FEATURES = [
@@ -64,6 +64,9 @@ export default function ConnectWalletPage() {
   const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
   const [errorExpanded, setErrorExpanded] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const [checkingNetwork, setCheckingNetwork] = useState(false);
+  const [freighterNetwork, setFreighterNetwork] = useState<"TESTNET" | "MAINNET" | null>(null);
+  const [isVersionOutdated, setIsVersionOutdated] = useState(false);
 
   useEffect(() => {
     if (isConnected && publicKey) {
@@ -116,6 +119,14 @@ export default function ConnectWalletPage() {
       setFreighterNetwork(null);
     }
   }, [isConnected, publicKey]);
+
+  // Check Freighter version on mount (only in browser, only when installed)
+  useEffect(() => {
+    if (!isFreighterInstalled) return;
+    isFreighterVersionSupported().then((supported) => {
+      setIsVersionOutdated(supported === false);
+    });
+  }, [isFreighterInstalled]);
 
 
   return (
@@ -193,6 +204,33 @@ export default function ConnectWalletPage() {
                 Link your Stellar wallet to start splitting rent with
                 trustless escrow. Secure, instant, transparent.
               </p>
+
+              {/* Outdated Freighter version banner */}
+              {isVersionOutdated && (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="w-full glass-card p-4 border border-amber-500/30 bg-amber-500/10 space-y-2"
+                >
+                  <div className="flex items-start gap-3">
+                    <AlertCircle className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />
+                    <div className="space-y-1">
+                      <p className="text-amber-300 text-sm font-semibold">
+                        Please update Freighter to version 10+.
+                      </p>
+                      <a
+                        href="https://chrome.google.com/webstore/detail/freighter/bcacfldlkkdogcmkkibnjlakofdplcbk"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-xs text-brand-400 hover:text-brand-300 transition-colors font-medium"
+                      >
+                        Update on Chrome Web Store
+                        <ExternalLink size={12} />
+                      </a>
+                    </div>
+                  </div>
+                </motion.div>
+              )}
 
               {/* Freighter detection */}
               {!isFreighterInstalled ? (

--- a/lib/stellar/wallet.ts
+++ b/lib/stellar/wallet.ts
@@ -88,6 +88,61 @@ export async function signTx(xdr: string, network?: string): Promise<string | nu
 }
 
 /**
+ * Returns the installed Freighter extension version string (e.g. "12.1.0"),
+ * or null if Freighter is not installed or the version cannot be determined.
+ */
+export async function getFreighterVersion(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+  try {
+    const win = window as Window & {
+      freighter?: { version?: string; getVersion?: () => string };
+    };
+    if (!win.freighter) return null;
+
+    if (typeof win.freighter.version === "string") {
+      return win.freighter.version;
+    }
+    if (typeof win.freighter.getVersion === "function") {
+      return win.freighter.getVersion() ?? null;
+    }
+
+    // Fallback: try the freighter-api module's getVersion export if present
+    const freighterModule = await import("@stellar/freighter-api");
+    if (typeof (freighterModule as Record<string, unknown>).getVersion === "function") {
+      const result = await (freighterModule as unknown as { getVersion: () => Promise<{ version: string }> }).getVersion();
+      return result?.version ?? null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const MINIMUM_FREIGHTER_VERSION = [10, 0, 0] as const;
+
+function parseVersion(v: string): [number, number, number] {
+  const parts = v.split(".").map(Number);
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+/**
+ * Returns true if the installed Freighter version meets the minimum requirement (10.0.0).
+ * Returns null when the version cannot be determined.
+ */
+export async function isFreighterVersionSupported(): Promise<boolean | null> {
+  const version = await getFreighterVersion();
+  if (!version) return null;
+
+  const [major, minor, patch] = parseVersion(version);
+  const [minMajor, minMinor, minPatch] = MINIMUM_FREIGHTER_VERSION;
+
+  if (major !== minMajor) return major > minMajor;
+  if (minor !== minMinor) return minor > minMinor;
+  return patch >= minPatch;
+}
+
+/**
  * Gets the current network of the connected Freighter wallet.
  * Returns "TESTNET" or "MAINNET" if connected and network can be determined.
  * Returns null if Freighter is not available, not connected, or network cannot be determined.


### PR DESCRIPTION
- Add getFreighterVersion() and isFreighterVersionSupported() to wallet.ts (minimum required version: 10.0.0)
- Fix missing useState declarations for checkingNetwork and freighterNetwork in app/connect/page.tsx
- Show amber banner on /connect when Freighter < v10 with a Chrome Web Store link for the update

closes #519 