### PR TITLE
feat(#510): Add date range filter to history page

### DIFF
--- a/__tests__/dateRangeFilter.test.ts
+++ b/__tests__/dateRangeFilter.test.ts
@@ -1,0 +1,144 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// ── Inline copy of the pure filtering logic from TransactionList ────────────
+// We test the filtering logic in isolation to avoid React/DOM dependencies.
+
+interface Transaction {
+  id: string;
+  type: "contribute" | "release" | "refund";
+  amount: string;
+  status: "success" | "pending" | "failed";
+  timestamp: string;
+  txHash: string;
+}
+
+function toLocalDate(iso: string): Date {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function filterByDateRange(
+  transactions: Transaction[],
+  dateFrom: string,
+  dateTo: string,
+): Transaction[] {
+  return transactions.filter((tx) => {
+    let match = true;
+    const txDate = new Date(tx.timestamp);
+
+    if (dateFrom) {
+      match = match && txDate >= toLocalDate(dateFrom);
+    }
+    if (dateTo) {
+      const toDate = toLocalDate(dateTo);
+      toDate.setHours(23, 59, 59, 999);
+      match = match && txDate <= toDate;
+    }
+    return match;
+  });
+}
+
+// ── Mock data: 5 transactions spread across different months ────────────────
+
+const MOCK_TRANSACTIONS: Transaction[] = [
+  {
+    id: "tx-1",
+    type: "contribute",
+    amount: "450.00 XLM",
+    status: "success",
+    timestamp: "2026-01-15T10:00:00.000Z",
+    txHash: "hash1",
+  },
+  {
+    id: "tx-2",
+    type: "release",
+    amount: "1,250.00 XLM",
+    status: "success",
+    timestamp: "2026-02-10T14:30:00.000Z",
+    txHash: "hash2",
+  },
+  {
+    id: "tx-3",
+    type: "contribute",
+    amount: "300.00 XLM",
+    status: "success",
+    timestamp: "2026-03-22T08:45:00.000Z",
+    txHash: "hash3",
+  },
+  {
+    id: "tx-4",
+    type: "refund",
+    amount: "150.00 XLM",
+    status: "success",
+    timestamp: "2026-04-05T20:00:00.000Z",
+    txHash: "hash4",
+  },
+  {
+    id: "tx-5",
+    type: "contribute",
+    amount: "500.00 XLM",
+    status: "failed",
+    timestamp: "2026-05-01T12:00:00.000Z",
+    txHash: "hash5",
+  },
+];
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("DateRangeFilter — filtering logic", () => {
+  it("returns all transactions when no dates are set", () => {
+    const result = filterByDateRange(MOCK_TRANSACTIONS, "", "");
+    assert.equal(result.length, 5, "All 5 transactions should be returned");
+  });
+
+  it("filters by 'from' date only — excludes earlier transactions", () => {
+    // From March 1 → should include tx-3 (Mar), tx-4 (Apr), tx-5 (May)
+    const result = filterByDateRange(MOCK_TRANSACTIONS, "2026-03-01", "");
+    assert.equal(result.length, 3);
+    assert.deepEqual(
+      result.map((t) => t.id),
+      ["tx-3", "tx-4", "tx-5"],
+    );
+  });
+
+  it("filters by 'to' date only — excludes later transactions", () => {
+    // To Feb 28 → should include tx-1 (Jan) and tx-2 (Feb)
+    const result = filterByDateRange(MOCK_TRANSACTIONS, "", "2026-02-28");
+    assert.equal(result.length, 2);
+    assert.deepEqual(
+      result.map((t) => t.id),
+      ["tx-1", "tx-2"],
+    );
+  });
+
+  it("filters by both 'from' and 'to' — returns correct subset", () => {
+    // Feb 1 → Mar 31 → should include tx-2 (Feb) and tx-3 (Mar)
+    const result = filterByDateRange(MOCK_TRANSACTIONS, "2026-02-01", "2026-03-31");
+    assert.equal(result.length, 2);
+    assert.deepEqual(
+      result.map((t) => t.id),
+      ["tx-2", "tx-3"],
+    );
+  });
+
+  it("includes transactions that fall on the exact 'from' date", () => {
+    // From the exact date of tx-1
+    const result = filterByDateRange(MOCK_TRANSACTIONS, "2026-01-15", "2026-01-15");
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "tx-1");
+  });
+
+  it("includes transactions that fall on the exact 'to' date (end of day)", () => {
+    // To date is the same day as tx-4 — should still include it
+    const result = filterByDateRange(MOCK_TRANSACTIONS, "2026-04-05", "2026-04-05");
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "tx-4");
+  });
+
+  it("returns empty array when no transactions match the range", () => {
+    // A gap where no transactions exist
+    const result = filterByDateRange(MOCK_TRANSACTIONS, "2026-06-01", "2026-06-30");
+    assert.equal(result.length, 0);
+  });
+});

--- a/components/history/DateRangeFilter.tsx
+++ b/components/history/DateRangeFilter.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { CalendarDays, X } from "lucide-react";
+
+interface DateRangeFilterProps {
+  /** Start of the date range (ISO "YYYY-MM-DD" or empty) */
+  from: string;
+  /** End of the date range (ISO "YYYY-MM-DD" or empty) */
+  to: string;
+  /** Called when the "From" date changes */
+  onFromChange: (value: string) => void;
+  /** Called when the "To" date changes */
+  onToChange: (value: string) => void;
+  /** Called when the user clicks "Clear" */
+  onClear: () => void;
+  /** Count of transactions visible after filtering */
+  filteredCount: number;
+  /** Total count of transactions before filtering */
+  totalCount: number;
+}
+
+/**
+ * A date range filter UI for the history page.
+ *
+ * Renders two native `mm/dd/yyyy` date inputs ("From" and "To"), a "Clear"
+ * button that resets both fields, and a result count badge.
+ */
+export default function DateRangeFilter({
+  from,
+  to,
+  onFromChange,
+  onToChange,
+  onClear,
+  filteredCount,
+  totalCount,
+}: DateRangeFilterProps) {
+  const isActive = from !== "" || to !== "";
+
+  return (
+    <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 w-full">
+      {/* From field */}
+      <div className="relative flex items-center flex-1 min-w-0">
+        <label htmlFor="date-from" className="sr-only">
+          From date
+        </label>
+        <span
+          className="pointer-events-none absolute left-3 text-dark-500"
+          aria-hidden="true"
+        >
+          <CalendarDays size={16} />
+        </span>
+        <input
+          id="date-from"
+          type="date"
+          value={from}
+          onChange={(e) => onFromChange(e.target.value)}
+          max={to || undefined}
+          aria-label="From date"
+          data-testid="date-range-from"
+          className="w-full bg-dark-900/50 border border-white/10 rounded-xl py-2.5 pl-10 pr-3 text-sm text-dark-100 placeholder:text-dark-600 focus:outline-none focus:border-brand-500 focus:ring-4 focus:ring-brand-500/10 transition-all font-medium [color-scheme:dark]"
+        />
+      </div>
+
+      {/* Separator */}
+      <span className="hidden sm:block text-dark-600 text-xs font-bold select-none">
+        –
+      </span>
+
+      {/* To field */}
+      <div className="relative flex items-center flex-1 min-w-0">
+        <label htmlFor="date-to" className="sr-only">
+          To date
+        </label>
+        <span
+          className="pointer-events-none absolute left-3 text-dark-500"
+          aria-hidden="true"
+        >
+          <CalendarDays size={16} />
+        </span>
+        <input
+          id="date-to"
+          type="date"
+          value={to}
+          onChange={(e) => onToChange(e.target.value)}
+          min={from || undefined}
+          aria-label="To date"
+          data-testid="date-range-to"
+          className="w-full bg-dark-900/50 border border-white/10 rounded-xl py-2.5 pl-10 pr-3 text-sm text-dark-100 placeholder:text-dark-600 focus:outline-none focus:border-brand-500 focus:ring-4 focus:ring-brand-500/10 transition-all font-medium [color-scheme:dark]"
+        />
+      </div>
+
+      {/* Clear button */}
+      {isActive && (
+        <button
+          type="button"
+          onClick={onClear}
+          data-testid="date-range-clear"
+          className="flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl text-xs font-bold text-dark-300 bg-white/5 border border-white/10 hover:bg-red-500/10 hover:text-red-300 hover:border-red-500/20 transition-all active:scale-95 whitespace-nowrap"
+        >
+          <X size={14} />
+          Clear
+        </button>
+      )}
+
+      {/* Result count badge */}
+      {isActive && (
+        <div
+          data-testid="date-range-count"
+          className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-brand-500/10 border border-brand-500/20 text-[11px] font-black text-brand-300 uppercase tracking-wider whitespace-nowrap"
+        >
+          Showing{" "}
+          <span className="text-white">{filteredCount}</span> of{" "}
+          <span className="text-white">{totalCount}</span> transactions
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/history/TransactionList.tsx
+++ b/components/history/TransactionList.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import TransactionCard, { type Transaction } from "./TransactionCard";
+import DateRangeFilter from "./DateRangeFilter";
 import { Search, Filter, ArrowRight, ArrowLeft } from "lucide-react";
 
 interface TransactionListProps {
@@ -12,21 +13,59 @@ interface TransactionListProps {
 }
 
 /**
+ * Returns the start-of-day Date for a given ISO date string (YYYY-MM-DD),
+ * interpreted as local time so the comparison is intuitive for the user.
+ */
+function toLocalDate(iso: string): Date {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/**
  * A container component for displaying a filtered and paginated list of transactions.
- * Features search and filter UI components for enhanced usability.
+ * Features search, date-range filter, and pagination UI.
  */
 export default function TransactionList({ initialTransactions }: TransactionListProps) {
   const [page, setPage] = useState(1);
   const itemsPerPage = 6;
-  
+
   const [searchQuery, setSearchQuery] = useState("");
-  
-  // Basic filtering for demo purposes
-  const filteredTransactions = initialTransactions.filter(tx => 
-    tx.txHash.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    tx.amount.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    tx.type.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  // ── Filtering ─────────────────────────────────────────────
+  const filteredTransactions = useMemo(() => {
+    return initialTransactions.filter((tx) => {
+      // Text search
+      const matchesSearch =
+        searchQuery === "" ||
+        tx.txHash.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        tx.amount.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        tx.type.toLowerCase().includes(searchQuery.toLowerCase());
+
+      // Date range
+      let matchesDate = true;
+      if (dateFrom || dateTo) {
+        const txDate = new Date(tx.timestamp);
+
+        if (dateFrom) {
+          const fromDate = toLocalDate(dateFrom);
+          matchesDate = matchesDate && txDate >= fromDate;
+        }
+
+        if (dateTo) {
+          const toDate = toLocalDate(dateTo);
+          // Include the entire "to" day (up to 23:59:59.999)
+          toDate.setHours(23, 59, 59, 999);
+          matchesDate = matchesDate && txDate <= toDate;
+        }
+      }
+
+      return matchesSearch && matchesDate;
+    });
+  }, [initialTransactions, searchQuery, dateFrom, dateTo]);
+
+  const isDateFilterActive = dateFrom !== "" || dateTo !== "";
 
   const totalPages = Math.ceil(filteredTransactions.length / itemsPerPage) || 1;
   const safePage = Math.min(page, totalPages);
@@ -36,34 +75,56 @@ export default function TransactionList({ initialTransactions }: TransactionList
     safePage * itemsPerPage
   );
 
+  function handleClearDates() {
+    setDateFrom("");
+    setDateTo("");
+    setPage(1);
+  }
+
   return (
     <div className="space-y-6">
       {/* List Control Header */}
-      <div className="flex flex-col md:flex-row gap-4 justify-between items-center mb-10 bg-white/5 border border-white/5 p-4 rounded-2xl backdrop-blur-md">
-        <div className="relative w-full md:w-96 group">
-          <label htmlFor="tx-search" className="sr-only">Search transactions</label>
-          <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-dark-500 group-focus-within:text-brand-400 transition-colors" />
-          <input
-            id="tx-search"
-            type="text"
-            placeholder="Search by amount, hash, or type..."
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
-              setPage(1);
-            }}
-            className="w-full bg-dark-900/50 border border-white/10 rounded-xl py-3 pl-11 pr-5 text-sm focus:outline-none focus:border-brand-500 focus:ring-4 focus:ring-brand-500/10 placeholder:text-dark-600 transition-all font-medium"
-          />
+      <div className="flex flex-col gap-4 mb-10 bg-white/5 border border-white/5 p-4 rounded-2xl backdrop-blur-md">
+        {/* Row 1: Search + existing buttons */}
+        <div className="flex flex-col md:flex-row gap-4 justify-between items-center">
+          <div className="relative w-full md:w-96 group">
+            <label htmlFor="tx-search" className="sr-only">Search transactions</label>
+            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-dark-500 group-focus-within:text-brand-400 transition-colors" />
+            <input
+              id="tx-search"
+              type="text"
+              placeholder="Search by amount, hash, or type..."
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                setPage(1);
+              }}
+              className="w-full bg-dark-900/50 border border-white/10 rounded-xl py-3 pl-11 pr-5 text-sm focus:outline-none focus:border-brand-500 focus:ring-4 focus:ring-brand-500/10 placeholder:text-dark-600 transition-all font-medium"
+            />
+          </div>
+
+          <div className="flex items-center gap-3 w-full md:w-auto">
+            <button className="flex-1 md:flex-none btn-secondary !py-2.5 !px-4 !text-xs !bg-dark-900/40 !border-white/10 hover:!border-white/20">
+              <Filter className="h-3.5 w-3.5" />
+              Types
+            </button>
+            <button className="flex-1 md:flex-none btn-secondary !py-2.5 !px-4 !text-xs !bg-dark-900/40 !border-white/10 hover:!border-white/20">
+              Latest First
+            </button>
+          </div>
         </div>
-        
-        <div className="flex items-center gap-3 w-full md:w-auto">
-          <button className="flex-1 md:flex-none btn-secondary !py-2.5 !px-4 !text-xs !bg-dark-900/40 !border-white/10 hover:!border-white/20">
-            <Filter className="h-3.5 w-3.5" />
-            Types
-          </button>
-          <button className="flex-1 md:flex-none btn-secondary !py-2.5 !px-4 !text-xs !bg-dark-900/40 !border-white/10 hover:!border-white/20">
-            Latest First
-          </button>
+
+        {/* Row 2: Date Range Filter */}
+        <div className="border-t border-white/5 pt-4">
+          <DateRangeFilter
+            from={dateFrom}
+            to={dateTo}
+            onFromChange={(v) => { setDateFrom(v); setPage(1); }}
+            onToChange={(v) => { setDateTo(v); setPage(1); }}
+            onClear={handleClearDates}
+            filteredCount={filteredTransactions.length}
+            totalCount={initialTransactions.length}
+          />
         </div>
       </div>
 
@@ -80,7 +141,19 @@ export default function TransactionList({ initialTransactions }: TransactionList
             <Search className="h-6 w-6 text-dark-600" />
           </div>
           <h3 className="text-dark-200 font-bold">No transactions found</h3>
-          <p className="text-dark-500 text-sm mt-1">Try adjusting your search criteria</p>
+          <p className="text-dark-500 text-sm mt-1">
+            {isDateFilterActive
+              ? "No transactions match the selected date range"
+              : "Try adjusting your search criteria"}
+          </p>
+          {isDateFilterActive && (
+            <button
+              onClick={handleClearDates}
+              className="mt-4 text-brand-400 text-sm font-bold hover:text-brand-300 transition-colors"
+            >
+              Clear date filter
+            </button>
+          )}
         </div>
       )}
 
@@ -89,7 +162,7 @@ export default function TransactionList({ initialTransactions }: TransactionList
         <p className="text-[11px] text-dark-500 uppercase tracking-widest font-black">
           Page <span className="text-brand-400 px-1">{safePage}</span> of <span className="text-dark-200 px-1">{totalPages}</span> — {filteredTransactions.length} Total
         </p>
-        
+
         <div className="flex items-center gap-3 bg-white/5 p-1 rounded-2xl border border-white/10 backdrop-blur-md">
           <button
             onClick={() => setPage(p => Math.max(1, p - 1))}
@@ -99,15 +172,15 @@ export default function TransactionList({ initialTransactions }: TransactionList
           >
             <ArrowLeft className="h-4 w-4" />
           </button>
-          
+
           <div className="hidden sm:flex items-center gap-1.5 px-3">
             {[...Array(totalPages)].map((_, i) => (
               <button
                 key={i}
                 onClick={() => setPage(i + 1)}
                 className={`h-10 w-10 rounded-xl text-xs font-black transition-all hover:scale-105 active:scale-95 ${
-                  safePage === i + 1 
-                    ? "bg-brand-500 text-white shadow-[0_4px_20px_rgba(76,110,245,0.4)] scale-110" 
+                  safePage === i + 1
+                    ? "bg-brand-500 text-white shadow-[0_4px_20px_rgba(76,110,245,0.4)] scale-110"
                     : "bg-white/5 text-dark-400 hover:bg-white/10"
                 }`}
               >


### PR DESCRIPTION
## Summary
Adds a date range filter UI to the transaction history page, allowing users to filter transactions by a From/To date range.

## Changes
- **[NEW] components/history/DateRangeFilter.tsx** — Reusable date range filter component with:
  - Two mm/dd/yyyy native date inputs (From and To)
  - Clear button that resets both filters
  - Result count badge: *Showing 3 of 12 transactions*
  - Styled to match the existing glassmorphism design system
- **[MODIFY] components/history/TransactionList.tsx** — Integrated DateRangeFilter into the list control header with client-side filtering logic
- **[NEW] __tests__/dateRangeFilter.test.ts** — 7 unit tests covering:
  - No filter returns all transactions
  - From-only filtering
  - To-only filtering
  - Both From and To filtering
  - Exact date boundary inclusion
  - Empty result set

## Acceptance Criteria
- [x] Setting a date range hides transactions outside the range
- [x] Clear button resets both filters
- [x] Result count shown when filter is active
- [x] All 7 tests pass

Closes #510 