### PR TITLE
feat(#513): Add export CSV functionality to history page

### DIFF
--- a/__tests__/exportCsv.test.ts
+++ b/__tests__/exportCsv.test.ts
@@ -33,10 +33,12 @@ const MOCK_TRANSACTIONS: Transaction[] = [
 describe("exportTransactionsToCsv", () => {
   let blobContent: string | null = null;
   let clickedElement: any = null;
+  let createElementMock: any = null;
 
   beforeEach(() => {
     blobContent = null;
     clickedElement = null;
+    createElementMock = null;
 
     // Mock global objects needed for browser download simulation
     global.Blob = class BlobMock {
@@ -60,8 +62,9 @@ describe("exportTransactionsToCsv", () => {
       }),
     };
 
+    createElementMock = mock.fn(() => mockElement);
     global.document = {
-      createElement: mock.fn(() => mockElement),
+      createElement: createElementMock,
       body: {
         appendChild: mock.fn(),
         removeChild: mock.fn(),
@@ -101,7 +104,7 @@ describe("exportTransactionsToCsv", () => {
 
     // 2. Verify download triggered
     assert.equal(
-      global.document.createElement.mock.calls[0].arguments[0],
+      createElementMock.mock.calls[0].arguments[0],
       "a",
       "Should create an anchor element"
     );

--- a/__tests__/exportCsv.test.ts
+++ b/__tests__/exportCsv.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { exportTransactionsToCsv } from "../lib/exportCsv.ts";
+import type { Transaction } from "@/components/history/TransactionCard";
+
+const MOCK_TRANSACTIONS: Transaction[] = [
+  {
+    id: "tx-1",
+    type: "contribute",
+    amount: "450.00 XLM",
+    status: "success",
+    timestamp: "2026-03-28T14:30:00.000Z",
+    txHash: "hash1",
+  },
+  {
+    id: "tx-2",
+    type: "release",
+    amount: "1,250.00 XLM",
+    status: "pending",
+    timestamp: "2026-03-25T09:12:45.000Z",
+    txHash: "hash2",
+  },
+  {
+    id: "tx-3",
+    type: "refund",
+    amount: "150.00 XLM",
+    status: "failed",
+    timestamp: "2026-03-15T11:20:00.000Z",
+    txHash: "hash3",
+  },
+];
+
+describe("exportTransactionsToCsv", () => {
+  let blobContent: string | null = null;
+  let clickedElement: any = null;
+
+  beforeEach(() => {
+    blobContent = null;
+    clickedElement = null;
+
+    // Mock global objects needed for browser download simulation
+    global.Blob = class BlobMock {
+      content: any[];
+      constructor(content: any[], options: any) {
+        this.content = content;
+        blobContent = content.join("");
+      }
+    } as any;
+
+    global.URL = {
+      createObjectURL: () => "blob:mocked-url",
+      revokeObjectURL: () => {},
+    } as any;
+
+    const mockElement = {
+      setAttribute: mock.fn(),
+      style: {},
+      click: mock.fn(() => {
+        clickedElement = mockElement;
+      }),
+    };
+
+    global.document = {
+      createElement: mock.fn(() => mockElement),
+      body: {
+        appendChild: mock.fn(),
+        removeChild: mock.fn(),
+      },
+    } as any;
+  });
+
+  it("generates correct CSV content and triggers download", () => {
+    exportTransactionsToCsv(MOCK_TRANSACTIONS);
+
+    // 1. Verify Blob content (the CSV string)
+    assert.ok(blobContent !== null, "Blob should have been created with CSV content");
+    
+    const lines = blobContent!.split("\n");
+    assert.equal(lines.length, 4, "Should have 1 header line + 3 data lines");
+    
+    // Verify headers
+    assert.equal(lines[0], "Date,Type,Amount,Fee,Hash,Status");
+
+    // Verify first row
+    // Note: Date formatting depends on locale in real usage, but the structure remains.
+    // We just check if the other fields are correctly escaped and placed.
+    assert.ok(lines[1].includes('"CONTRIBUTE"'));
+    assert.ok(lines[1].includes('"450.00 XLM"'));
+    assert.ok(lines[1].includes('"N/A"')); // default fee
+    assert.ok(lines[1].includes('"hash1"'));
+    assert.ok(lines[1].includes('"SUCCESS"'));
+
+    // Verify second row
+    assert.ok(lines[2].includes('"RELEASE"'));
+    assert.ok(lines[2].includes('"1,250.00 XLM"')); // handles comma in amount via escaping
+    assert.ok(lines[2].includes('"PENDING"'));
+
+    // Verify third row
+    assert.ok(lines[3].includes('"REFUND"'));
+    assert.ok(lines[3].includes('"FAILED"'));
+
+    // 2. Verify download triggered
+    assert.equal(
+      global.document.createElement.mock.calls[0].arguments[0],
+      "a",
+      "Should create an anchor element"
+    );
+    
+    const setAttributeCalls = clickedElement.setAttribute.mock.calls;
+    assert.equal(setAttributeCalls[0].arguments[0], "href");
+    assert.equal(setAttributeCalls[0].arguments[1], "blob:mocked-url");
+    
+    assert.equal(setAttributeCalls[1].arguments[0], "download");
+    assert.ok(setAttributeCalls[1].arguments[1].startsWith("payeasy-history-"));
+    assert.ok(setAttributeCalls[1].arguments[1].endsWith(".csv"));
+
+    assert.equal(clickedElement.click.mock.calls.length, 1, "Should click the link to trigger download");
+  });
+});

--- a/components/history/TransactionList.tsx
+++ b/components/history/TransactionList.tsx
@@ -3,7 +3,8 @@
 import { useState, useMemo } from "react";
 import TransactionCard, { type Transaction } from "./TransactionCard";
 import DateRangeFilter from "./DateRangeFilter";
-import { Search, Filter, ArrowRight, ArrowLeft } from "lucide-react";
+import { Search, Filter, ArrowRight, ArrowLeft, Download } from "lucide-react";
+import { exportTransactionsToCsv } from "@/lib/exportCsv";
 
 interface TransactionListProps {
   /**
@@ -110,6 +111,13 @@ export default function TransactionList({ initialTransactions }: TransactionList
             </button>
             <button className="flex-1 md:flex-none btn-secondary !py-2.5 !px-4 !text-xs !bg-dark-900/40 !border-white/10 hover:!border-white/20">
               Latest First
+            </button>
+            <button 
+              onClick={() => exportTransactionsToCsv(filteredTransactions)}
+              className="flex-1 md:flex-none btn-primary !py-2.5 !px-4 !text-xs shadow-lg shadow-brand-500/20"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export CSV
             </button>
           </div>
         </div>

--- a/lib/exportCsv.ts
+++ b/lib/exportCsv.ts
@@ -1,0 +1,53 @@
+import type { Transaction } from "@/components/history/TransactionCard";
+
+/**
+ * Converts an array of transactions to a CSV string and triggers a browser download.
+ *
+ * @param transactions The list of transactions to export.
+ */
+export function exportTransactionsToCsv(transactions: Transaction[]) {
+  // Define columns: Date, Type, Amount, Fee, Hash, Status
+  const headers = ["Date", "Type", "Amount", "Fee", "Hash", "Status"];
+
+  // Map transactions to CSV rows
+  const rows = transactions.map((tx) => {
+    // Format date nicely
+    const date = new Date(tx.timestamp).toLocaleString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+    // Escape quotes and fields containing commas
+    const escapeCsv = (field: string) => `"${field.replace(/"/g, '""')}"`;
+
+    return [
+      escapeCsv(date),
+      escapeCsv(tx.type.toUpperCase()),
+      escapeCsv(tx.amount),
+      escapeCsv((tx as any).fee || "N/A"), // Fallback if fee is not in type
+      escapeCsv(tx.txHash),
+      escapeCsv(tx.status.toUpperCase()),
+    ].join(",");
+  });
+
+  // Combine headers and rows
+  const csvContent = [headers.join(","), ...rows].join("\n");
+
+  // Create a Blob and trigger download
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  
+  const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+  const filename = `payeasy-history-${today}.csv`;
+
+  const link = document.createElement("a");
+  link.setAttribute("href", url);
+  link.setAttribute("download", filename);
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}


### PR DESCRIPTION
## Summary
Adds an Export CSV button to the transaction history page that allows users to download their currently filtered list of transactions.

## Changes
- **[NEW] lib/exportCsv.ts** — Utility function that formats an array of transactions into a CSV string and triggers a browser download using Blob and URL.createObjectURL.
- **[MODIFY] components/history/TransactionList.tsx** — Added the Export CSV button to the header area. It calls the export function with the \ilteredTransactions\ array, ensuring it perfectly respects whatever search or future filters the user has applied.
- **[NEW] __tests__/exportCsv.test.ts** — Unit tests that mock browser globals (\Blob\, \URL\, \document\) to verify that the CSV output structure is correct and that the download is triggered properly.

## Acceptance Criteria
- [x] Columns: Date, Type, Amount, Fee, Hash, Status.
- [x] File name: \payeasy-history-YYYY-MM-DD.csv\. Uses browser Blob + anchor download.
- [x] Respects currently active filters.
- [x] Clicking Export CSV downloads a file with the correct number of rows.

Closes #513 