### PR TITLE
fix: improve responsive mobile layout and add SEO meta tags

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,21 @@ export const metadata: Metadata = {
       "Find roommates, split rent, and pay securely through Stellar blockchain escrow.",
     type: "website",
     url: "https://payeasy.dev",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "PayEasy - Blockchain-Powered Rent Sharing",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "PayEasy — Blockchain-Powered Rent Sharing",
+    description:
+      "Find roommates, split rent, and pay securely through Stellar blockchain escrow.",
+    images: ["/og-image.png"],
   },
 };
 

--- a/components/escrow/RoommateInput.tsx
+++ b/components/escrow/RoommateInput.tsx
@@ -51,7 +51,7 @@ export default function RoommateInput({
           type="button"
           onClick={() => onRemove(roommate.id)}
           disabled={disableRemove}
-          className="text-xs px-3 py-1 rounded-md border border-white/10 text-dark-400 hover:text-dark-200 disabled:opacity-40 disabled:cursor-not-allowed"
+          className="text-xs px-3 py-2.5 sm:py-1 rounded-md border border-white/10 text-dark-400 hover:text-dark-200 disabled:opacity-40 disabled:cursor-not-allowed min-h-11 sm:min-h-auto flex items-center justify-center"
         >
           Remove
         </button>

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,4 +1,7 @@
-import { Github, Twitter } from "lucide-react";
+"use client";
+
+import { useState } from "react";
+import { Github, Twitter, ChevronDown } from "lucide-react";
 import Link from "next/link";
 
 const footerLinks = {
@@ -22,7 +25,24 @@ const footerLinks = {
   ],
 };
 
+interface AccordionState {
+  [key: string]: boolean;
+}
+
 export default function Footer() {
+  const [expandedCategories, setExpandedCategories] = useState<AccordionState>({
+    Product: true,
+    Resources: true,
+    Community: true,
+  });
+
+  const toggleCategory = (category: string) => {
+    setExpandedCategories((prev) => ({
+      ...prev,
+      [category]: !prev[category],
+    }));
+  };
+
   return (
     <footer className="border-t border-white/5 pt-16 pb-8 px-6">
       <div className="max-w-7xl mx-auto">
@@ -61,13 +81,37 @@ export default function Footer() {
             </div>
           </div>
 
-          {/* Link Columns */}
+          {/* Link Columns - Accordion on mobile, regular grid on desktop */}
           {Object.entries(footerLinks).map(([category, links]) => (
-            <div key={category}>
-              <h4 className="text-sm font-semibold text-white mb-4 uppercase tracking-wider">
+            <div key={category} className="lg:block">
+              {/* Mobile accordion header */}
+              <button
+                onClick={() => toggleCategory(category)}
+                className="lg:hidden w-full flex items-center justify-between mb-3"
+                aria-expanded={expandedCategories[category]}
+              >
+                <h4 className="text-sm font-semibold text-white uppercase tracking-wider">
+                  {category}
+                </h4>
+                <ChevronDown
+                  size={16}
+                  className={`transition-transform duration-200 ${
+                    expandedCategories[category] ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+
+              {/* Desktop header (always visible) */}
+              <h4 className="hidden lg:block text-sm font-semibold text-white mb-4 uppercase tracking-wider">
                 {category}
               </h4>
-              <ul className="space-y-3">
+
+              {/* Link list - collapsible on mobile */}
+              <ul
+                className={`space-y-3 lg:block ${
+                  expandedCategories[category] ? "block" : "hidden"
+                }`}
+              >
                 {links.map((link) => (
                   <li key={link.name}>
                     <a

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -55,7 +55,7 @@ export default function Navbar() {
 
         {/* CTA Buttons */}
         <div className="hidden md:flex items-center gap-3">
-          <a href="#" className="btn-secondary !py-2.5 !px-5 !text-sm !rounded-lg">
+          <a href="#" className="btn-secondary !py-2.5 !px-5 !text-sm !rounded-lg min-h-auto">
             Sign In
           </a>
           <ConnectWalletButton />
@@ -64,7 +64,7 @@ export default function Navbar() {
         {/* Mobile Menu Toggle */}
         <button
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          className="md:hidden text-white p-2"
+          className="md:hidden text-white min-h-11 min-w-11 flex items-center justify-center"
           aria-label="Toggle menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -80,13 +80,13 @@ export default function Navbar() {
                 key={link.name}
                 href={link.href}
                 onClick={() => setIsMobileMenuOpen(false)}
-                className="text-dark-300 hover:text-white transition-colors py-2 text-lg font-medium"
+                className="text-dark-300 hover:text-white transition-colors py-3 px-2 text-lg font-medium min-h-11 flex items-center"
               >
                 {link.name}
               </a>
             ))}
             <div className="h-px bg-white/10 my-2" />
-            <a href="#" className="btn-secondary !justify-center">
+            <a href="#" className="btn-secondary !justify-center min-h-11 flex items-center">
               Sign In
             </a>
             <div className="flex justify-center">

--- a/components/ui/payeasy-hero.tsx
+++ b/components/ui/payeasy-hero.tsx
@@ -312,17 +312,17 @@ export function PayEasyHero({
               initial={{ opacity: 0, y: 40 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.9 }}
-              className="mt-16 glass-card flex flex-col sm:flex-row items-center justify-center divide-y sm:divide-y-0 sm:divide-x divide-white/5 px-4 sm:px-0"
+              className="mt-16 glass-card flex flex-col sm:flex-row items-center justify-center divide-y sm:divide-y-0 sm:divide-x divide-white/5 w-full"
             >
               {stats.map((stat, index) => (
                 <div
                   key={index}
-                  className="flex flex-col items-center py-5 sm:py-6 px-8 sm:px-12"
+                  className="flex flex-col items-center justify-center py-6 px-6 sm:px-8 lg:px-12 w-full sm:w-auto"
                 >
-                  <span className="gradient-text font-display font-bold text-2xl">
+                  <span className="gradient-text font-display font-bold text-2xl sm:text-3xl whitespace-nowrap">
                     {stat.value}
                   </span>
-                  <span className="text-[13px] text-dark-600 mt-1">
+                  <span className="text-[13px] text-dark-600 mt-2 text-center break-words">
                     {stat.label}
                   </span>
                 </div>

--- a/components/wallet/ConnectWalletButton.tsx
+++ b/components/wallet/ConnectWalletButton.tsx
@@ -90,7 +90,7 @@ export default function ConnectWalletButton() {
             }
           }}
           disabled={isConnecting}
-          className="btn-primary !py-2.5 !px-5 !text-sm !rounded-lg flex items-center gap-2 group transition-all hover:scale-105 active:scale-95 disabled:opacity-50"
+          className="btn-primary !py-3 sm:!py-2.5 !px-5 !text-sm !rounded-lg flex items-center gap-2 group transition-all hover:scale-105 active:scale-95 disabled:opacity-50 min-h-11 sm:min-h-auto"
         >
           <Wallet size={16} className="group-hover:rotate-12 transition-transform" />
           {isConnecting ? "Connecting..." : "Connect Wallet"}
@@ -123,7 +123,7 @@ export default function ConnectWalletButton() {
     <>
       <button
         onClick={handleCopy}
-        className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-dark-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+        className="w-full flex items-center gap-3 px-4 py-3 sm:px-3 sm:py-2.5 text-sm text-dark-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors min-h-11 sm:min-h-auto"
       >
         {copied ? (
           <Check size={16} className="text-emerald-500" />
@@ -135,7 +135,7 @@ export default function ConnectWalletButton() {
 
       <button
         onClick={() => { setIsOpen(false); router.push("/connect"); }}
-        className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-dark-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+        className="w-full flex items-center gap-3 px-4 py-3 sm:px-3 sm:py-2.5 text-sm text-dark-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors min-h-11 sm:min-h-auto"
       >
         <ExternalLink size={16} />
         <span>Wallet Dashboard</span>
@@ -145,7 +145,7 @@ export default function ConnectWalletButton() {
 
       <button
         onClick={confirmDisconnect}
-        className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-rose-400 hover:text-rose-300 hover:bg-rose-500/10 rounded-lg transition-colors"
+        className="w-full flex items-center gap-3 px-4 py-3 sm:px-3 sm:py-2.5 text-sm text-rose-400 hover:text-rose-300 hover:bg-rose-500/10 rounded-lg transition-colors min-h-11 sm:min-h-auto"
       >
         <LogOut size={16} />
         <span>Disconnect</span>
@@ -157,7 +157,7 @@ export default function ConnectWalletButton() {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="glass-button flex items-center gap-2 px-4 py-2.5 rounded-lg border border-white/10 hover:bg-white/5 transition-all"
+        className="glass-button flex items-center gap-2 px-4 py-3 sm:py-2.5 rounded-lg border border-white/10 hover:bg-white/5 transition-all min-h-11 sm:min-h-auto"
       >
         <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
         <span className="text-sm font-medium text-white font-mono">{truncatedKey}</span>

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,43 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a0f;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1a1a2e;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient id="accentGradient" cx="30%" cy="30%">
+      <stop offset="0%" style="stop-color:#5c7cfa;stop-opacity:0.3" />
+      <stop offset="100%" style="stop-color:#20c997;stop-opacity:0.1" />
+    </radialGradient>
+  </defs>
+  
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  <circle cx="600" cy="315" r="400" fill="url(#accentGradient)"/>
+  
+  <!-- Logo -->
+  <circle cx="150" cy="150" r="50" fill="#5c7cfa"/>
+  <text x="150" y="170" font-size="60" font-weight="bold" fill="white" text-anchor="middle" font-family="Arial, sans-serif">P</text>
+  
+  <!-- Main heading -->
+  <text x="600" y="180" font-size="72" font-weight="bold" fill="white" text-anchor="middle" font-family="Arial, sans-serif">
+    PayEasy
+  </text>
+  
+  <!-- Subtitle -->
+  <text x="600" y="270" font-size="36" fill="#20c997" text-anchor="middle" font-family="Arial, sans-serif">
+    Blockchain-Powered Rent Sharing
+  </text>
+  
+  <!-- Description -->
+  <text x="600" y="340" font-size="24" fill="#c0c0c0" text-anchor="middle" font-family="Arial, sans-serif">
+    Find roommates. Split rent. Pay securely.
+  </text>
+  <text x="600" y="385" font-size="24" fill="#c0c0c0" text-anchor="middle" font-family="Arial, sans-serif">
+    Built on Stellar blockchain.
+  </text>
+  
+  <!-- URL -->
+  <text x="600" y="550" font-size="18" fill="#808080" text-anchor="middle" font-family="Arial, sans-serif">
+    payeasy.dev
+  </text>
+</svg>


### PR DESCRIPTION
- Add OG image meta tags and twitter:card to root layout (Closes #541)

- Make footer link columns collapsible accordions on mobile (Closes #538)

- Stack hero stats bar vertically on small screens with improved spacing (Closes #534)

- Ensure all interactive elements meet 44x44px minimum touch target size (Closes #533)

  - Update ConnectWalletButton with larger touch targets on mobile
  - Update Navbar menu toggle and mobile menu items
  - Update RoommateInput Remove button to meet minimum size