### PR TITLE
feat: a11y Form Field Labels and Descriptions

### DIFF
--- a/components/escrow/ContributeForm.tsx
+++ b/components/escrow/ContributeForm.tsx
@@ -117,10 +117,15 @@ export default function ContributeForm({
               type="number"
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
+              aria-invalid={!isValid && parseFloat(amount) > 0}
+              aria-describedby={[
+                !isValid && parseFloat(amount) > 0 ? "amount-error" : undefined,
+                "amount-helper"
+              ].filter(Boolean).join(" ") || undefined}
               className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-4 pr-12 text-lg font-bold text-dark-100 focus:border-brand-400 focus:outline-none transition-all group-hover:bg-white/[0.08]"
               placeholder="0.00"
             />
-            <div className="absolute right-4 top-1/2 -translate-y-1/2 text-dark-500 font-black text-sm">
+            <div id="amount-helper" className="absolute right-4 top-1/2 -translate-y-1/2 text-dark-500 font-black text-sm">
               XLM
             </div>
           </div>
@@ -138,7 +143,7 @@ export default function ContributeForm({
       </div>
 
   {!isValid && parseFloat(amount) > 0 && (
-    <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 p-3 rounded-xl flex items-center gap-2">
+    <div id="amount-error" role="alert" className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 p-3 rounded-xl flex items-center gap-2">
       <ArrowRight className="h-3 w-3 rotate-180" />
       {validation.error}
     </div>

--- a/components/escrow/CreateEscrowForm.tsx
+++ b/components/escrow/CreateEscrowForm.tsx
@@ -496,12 +496,12 @@ export default function CreateEscrowForm({
                 setDraft((current) => ({ ...current, deadlineDate: event.target.value }));
                 if (event.target.value) clearFieldError("deadlineDate");
               }}
-              aria-describedby={fieldErrors.deadlineDate ? "deadline-date-error" : undefined}
+              aria-describedby={[fieldErrors.deadlineDate ? "deadline-date-error" : undefined, "deadline-helper"].filter(Boolean).join(" ") || undefined}
               aria-invalid={!!fieldErrors.deadlineDate}
               className={`w-full rounded-xl border bg-white/5 px-4 py-3 text-dark-100 focus:outline-none transition-colors ${fieldBorderClass(fieldErrors.deadlineDate, !!draft.deadlineDate)}`}
             />
             <FieldError id="deadline-date-error" message={fieldErrors.deadlineDate} />
-            <p className="text-sm text-dark-500">
+            <p id="deadline-helper" className="text-sm text-dark-500">
               Ledger timestamp: {deadlineLedgerTimestamp ?? "-"}
             </p>
           </div>

--- a/components/escrow/RoommateInput.tsx
+++ b/components/escrow/RoommateInput.tsx
@@ -89,7 +89,7 @@ export default function RoommateInput({
             Share Amount
           </label>
           {percentage !== null && (
-            <span className="text-xs font-medium text-brand-300">({percentage}%)</span>
+            <span id={`roommate-share-helper-${roommate.id}`} className="text-xs font-medium text-brand-300">({percentage}%)</span>
           )}
         </div>
         <input
@@ -103,7 +103,10 @@ export default function RoommateInput({
             if (event.target.value && Number(event.target.value) > 0) onClearError?.(roommate.id, "shareAmount");
           }}
           placeholder="0"
-          aria-describedby={errors.shareAmount ? shareErrorId : undefined}
+          aria-describedby={[
+            errors.shareAmount ? shareErrorId : undefined,
+            percentage !== null ? `roommate-share-helper-${roommate.id}` : undefined
+          ].filter(Boolean).join(" ") || undefined}
           aria-invalid={!!errors.shareAmount}
           className={`w-full rounded-xl border bg-white/5 px-3 py-2 text-sm text-dark-100 placeholder:text-dark-600 focus:outline-none transition-colors ${fieldBorderClass(errors.shareAmount, !!roommate.shareAmount && Number(roommate.shareAmount) > 0)}`}
         />


### PR DESCRIPTION
Closes #526

## Description
This PR addresses accessibility issues in the core escrow flow by ensuring all input fields are properly described to screen readers using `aria-describedby` and `aria-invalid`. 

## Changes Included
- **Audited Labels**: Confirmed that all inputs in `CreateEscrowForm`, `RoommateInput`, and `ContributeForm` are already correctly linked to `<label>` tags via the `htmlFor` and `id` pattern.
- **Wired Helper Text**: 
  - Added an `id` to the "Ledger timestamp" display in the Escrow setup form and linked it to the `DateInput`.
  - Added an `id` to the calculated percentage display in `RoommateInput` and appended it to the input's `aria-describedby` chain.
  - Linked the "XLM" suffix and the error alert directly to the input in `ContributeForm`.
