### PR TITLE
fix: responsive mobile layout, landscape orientation, and SEO improvements

### DIFF
--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -187,12 +187,12 @@ export default function ConnectWalletPage() {
                 initial={{ scale: 0 }}
                 animate={{ scale: 1 }}
                 transition={{ type: "spring", stiffness: 200, delay: 0.1 }}
-                className="mb-8 p-5 rounded-2xl glass-card"
+                className="mb-8 landscape:mb-4 p-5 landscape:p-3 rounded-2xl glass-card"
                 style={{
                   boxShadow: "0 0 40px rgba(92,124,250,0.15)",
                 }}
               >
-                <Wallet className="w-10 h-10 text-brand-400" />
+                <Wallet className="w-10 h-10 landscape:w-7 landscape:h-7 text-brand-400" />
               </motion.div>
 
               {/* Heading */}
@@ -486,8 +486,8 @@ export default function ConnectWalletPage() {
                   </div>
                 </div>
 
-                <div className="flex items-center gap-2">
-                  <code className="flex-1 text-sm text-dark-200 bg-dark-950/60 rounded-xl px-4 py-3 font-mono truncate border border-white/5">
+                <div className="flex items-center gap-2 min-w-0">
+                  <code className="flex-1 min-w-0 text-sm text-dark-200 bg-dark-950/60 rounded-xl px-4 py-3 font-mono truncate border border-white/5">
                     {publicKey}
                   </code>
                   <button
@@ -537,7 +537,7 @@ export default function ConnectWalletPage() {
               )}
 
               {/* Action buttons */}
-              <div className="w-full grid grid-cols-2 gap-3 mt-6">
+              <div className="w-full grid grid-cols-1 sm:grid-cols-2 gap-3 mt-6">
                 <Link
                   href="/escrow/create"
                   className="btn-primary !justify-center !rounded-xl !py-3.5 text-sm"

--- a/app/escrow/[contractId]/page.tsx
+++ b/app/escrow/[contractId]/page.tsx
@@ -6,8 +6,8 @@ export async function generateMetadata({ params }: { params: { contractId: strin
     ? params.contractId
     : `${params.contractId.slice(0, 4)}...${params.contractId.slice(-4)}`;
   return {
-    title: `Escrow Agreement ${shortId} | PayEasy`,
-    description: `Monitor the real-time funding status and roommate contributions for rent escrow agreement ${params.contractId}.`,
+    title: `Escrow ${shortId} — PayEasy`,
+    description: `Manage Stellar escrow contract ${params.contractId} on PayEasy. Trustlessly collect and track rent payments powered by the Stellar blockchain.`,
   };
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,8 +12,28 @@ import Footer from "@/components/landing/Footer";
 export default function Home() {
   const router = useRouter();
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "PayEasy",
+    description:
+      "Find roommates, split rent, and pay securely through Stellar blockchain escrow. Transparent, trustless, and effortless.",
+    applicationCategory: "FinanceApplication",
+    operatingSystem: "Web",
+    url: "https://payeasy.dev",
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  };
+
   return (
     <main id="main-content" aria-label="Landing Page">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <PayEasyHero
         logo={<PayEasyLogo size={34} />}
         navigation={[

--- a/components/ui/payeasy-hero.tsx
+++ b/components/ui/payeasy-hero.tsx
@@ -71,7 +71,7 @@ export function PayEasyHero({
   return (
     <section
       className={cn(
-        "relative w-full min-h-screen flex flex-col overflow-hidden",
+        "relative w-full min-h-[100svh] flex flex-col overflow-hidden",
         className
       )}
       style={{


### PR DESCRIPTION
## Summary

- **#537** Connect page action buttons are now full-width on mobile (`grid-cols-1 sm:grid-cols-2`); address code block gains `min-w-0` to prevent flex overflow on 375 px viewports
- **#539** Hero section uses `min-h-[100svh]` instead of `min-h-screen` so the CTA is visible in landscape on iPhone SE; connect page wallet icon shrinks on landscape via `landscape:p-3 / landscape:w-7 landscape:h-7`
- **#540** Escrow dynamic metadata title updated to `Escrow {shortId} — PayEasy` with a Stellar-focused description
- **#542** Homepage now injects a `SoftwareApplication` JSON-LD script for schema.org structured data / search engine rich results

## Test plan

- [ ] Open `/connect` at 375 px width — action buttons stack vertically, address truncates without horizontal overflow
- [ ] Open `/connect` on iPhone SE landscape (667 px wide) — wallet icon is smaller, page fits without scrolling
- [ ] Open hero on iPhone SE landscape — CTA is visible without scrolling
- [ ] View source of `/escrow/CABC1234` — `<title>` shows `Escrow CABC...1234 — PayEasy`
- [ ] View source of `/` — JSON-LD script with `SoftwareApplication` schema is present in the HTML

closes #537
closes #539
closes #540
closes #542