### PR TITLE
Adding Hero

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,11 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Space+Grotesk:wght@700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap');
-
 @layer base {
   * {
     margin: 0;
@@ -21,7 +16,7 @@
   }
 
   body {
-    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    font-family: var(--font-inter), system-ui, -apple-system, sans-serif;
     background-color: #0a0a0f;
     color: #f1f3f5;
     overflow-x: hidden;
@@ -29,12 +24,12 @@
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-family: var(--font-space-grotesk), system-ui, sans-serif;
     letter-spacing: -0.035em;
   }
 
   code, pre, .font-mono {
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
   }
 
   ::selection {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,30 @@
 import type { Metadata } from "next";
+import { Inter, JetBrains_Mono, Space_Grotesk } from "next/font/google";
 import "@/lib/env";
 import { AppShell } from "@/components/ui/app-shell";
 import { StellarAuthProvider } from "@/contexts/StellarAuthContext";
 import "./globals.css";
 
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-space-grotesk",
+  display: "swap",
+});
+
+const jetBrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains-mono",
+  display: "swap",
+});
+
 export const metadata: Metadata = {
+  metadataBase: new URL("https://payeasy.dev"),
   title: "PayEasy — Blockchain-Powered Rent Sharing for Roommates",
   description:
     "Find roommates, split rent, and pay securely through Stellar blockchain escrow. PayEasy makes rent sharing transparent, trustless, and effortless.",
@@ -32,7 +52,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body>
+      <body
+        className={`${inter.variable} ${spaceGrotesk.variable} ${jetBrainsMono.variable} font-sans`}
+      >
         <StellarAuthProvider>
           <AppShell>{children}</AppShell>
         </StellarAuthProvider>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -6,9 +6,8 @@ export default function NotFound() {
     <main aria-label="Page Not Found" className="min-h-screen flex flex-col items-center justify-center px-6 text-center">
       {/* Floating "404" */}
       <div
-        className="animate-float select-none mb-8"
+        className="animate-float select-none mb-8 font-display"
         aria-hidden="true"
-        style={{ fontFamily: "'Space Grotesk', sans-serif" }}
       >
         <span
           className="text-[10rem] font-bold leading-none gradient-text"
@@ -19,8 +18,7 @@ export default function NotFound() {
       </div>
 
       <h1
-        className="text-2xl font-bold text-white mb-3"
-        style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+        className="text-2xl font-bold text-white mb-3 font-display"
       >
         Page not found
       </h1>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = "https://payeasy.dev";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/connect", "/history"],
+        disallow: "/escrow/",
+      },
+    ],
+    host: siteUrl,
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = "https://payeasy.dev";
+const routes = [
+  "/",
+  "/connect",
+  "/history",
+  "/escrow/create",
+  "/privacy",
+  "/terms",
+] as const;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return routes.map((route) => ({
+    url: `${siteUrl}${route}`,
+    lastModified,
+  }));
+}

--- a/components/ui/payeasy-hero.tsx
+++ b/components/ui/payeasy-hero.tsx
@@ -378,6 +378,8 @@ export function PayEasyHero({
                   src={program.image}
                   alt={program.title}
                   fill
+                  priority={index === 0}
+                  sizes="(max-width: 640px) 80vw, 320px"
                   className="w-full h-full object-cover"
                 />
                 <div

--- a/next.config.js
+++ b/next.config.js
@@ -40,10 +40,12 @@ const nextConfig = {
       {
         protocol: "https",
         hostname: "i.pravatar.cc",
+        pathname: "/**",
       },
       {
         protocol: "https",
         hostname: "images.unsplash.com",
+        pathname: "/**",
       },
     ],
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,9 +47,9 @@ const config: Config = {
         },
       },
       fontFamily: {
-        sans: ["Inter", "system-ui", "-apple-system", "sans-serif"],
-        display: ["Space Grotesk", "system-ui", "sans-serif"],
-        mono: ["JetBrains Mono", "ui-monospace", "monospace"],
+        sans: ["var(--font-inter)", "system-ui", "-apple-system", "sans-serif"],
+        display: ["var(--font-space-grotesk)", "system-ui", "sans-serif"],
+        mono: ["var(--font-jetbrains-mono)", "ui-monospace", "monospace"],
       },
       animation: {
         "fade-in": "fadeIn 0.6s ease-out forwards",


### PR DESCRIPTION
Title
  SEO + hero image optimizations for issues #124-#127

  Body

  Closes #543 
  Closes #544 
  Closes #545 
  Closes #546 
  ## Summary
  - added `app/sitemap.ts` to generate a sitemap for the static public routes
  - added `app/robots.ts` to allow `/`, `/connect`, and `/history`, and disallow `/escrow/`
  - migrated Google Fonts from CSS `@import` to `next/font/google` with CSS variables
  - updated global and Tailwind font usage to use the self-hosted font variables consistently
  - set the first visible hero carousel image to `priority`
  - kept remote image support explicit in `next.config.js` for Unsplash and Pravatar