### PR TITLE
perf: WebGL fallback, low-end device guard, lazy carousel images, memoized escrow computations

### DIFF
--- a/app/escrow/[contractId]/EscrowDashboardClient.tsx
+++ b/app/escrow/[contractId]/EscrowDashboardClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import EscrowStatus from "@/components/escrow/EscrowStatus";
 import FundingProgress from "@/components/escrow/FundingProgress";
 import MultiSigApproval from "@/components/escrow/MultiSigApproval";
@@ -61,6 +61,33 @@ export default function EscrowDashboardClient({ contractId }: Props) {
   const currentRoommate = contractState?.roommates.find(
     (r) => r.address === publicKey
   );
+
+  // #550 — memoize derived values so they don't recompute on unrelated state changes.
+  const totalFunded = useMemo(
+    () =>
+      contractState
+        ? contractState.roommates.reduce(
+            (sum, r) => sum + Number(r.paidAmount),
+            0
+          )
+        : 0,
+    [contractState]
+  );
+
+  const fundingPercentage = useMemo(() => {
+    if (!contractState || Number(contractState.totalRent) === 0) return 0;
+    return Math.min(
+      100,
+      (totalFunded / Number(contractState.totalRent)) * 100
+    );
+  }, [contractState, totalFunded]);
+
+  const roommateStatusMap = useMemo(() => {
+    if (!contractState) return new Map<string, boolean>();
+    return new Map(
+      contractState.roommates.map((r) => [r.address, r.isPaid])
+    );
+  }, [contractState]);
 
   const nowEpoch = Math.floor(Date.now() / 1000);
   const isDeadlinePassed =

--- a/components/ui/app-shell.tsx
+++ b/components/ui/app-shell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { ThemeProvider } from "@/components/ui/theme-provider";
 import { DottedSurface } from "@/components/ui/dotted-surface";
 import { StellarProvider } from "@/context/StellarContext";
@@ -7,6 +8,12 @@ import { ToastProvider } from "@/components/ui/toast-provider";
 import { SkipLink } from "@/components/ui/skip-link";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import OfflineBanner from "./offline-banner";
+
+/** True when the device reports fewer than 4 logical CPU cores. */
+const isLowEnd =
+  typeof navigator !== "undefined" &&
+  typeof navigator.hardwareConcurrency === "number" &&
+  navigator.hardwareConcurrency < 4;
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (
@@ -16,7 +23,19 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       enableSystem={false}
       disableTransitionOnChange
     >
-      <DottedSurface />
+      {/* #548: skip Three.js canvas on low-end devices; use a lightweight CSS gradient instead */}
+      {isLowEnd ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none fixed inset-0 -z-[1]"
+          style={{
+            background:
+              "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(92,124,250,0.10) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 80% 100%, rgba(32,201,151,0.06) 0%, transparent 60%)",
+          }}
+        />
+      ) : (
+        <DottedSurface />
+      )}
       <div className="mesh-gradient" aria-hidden="true" />
       <SkipLink />
       <StellarProvider>

--- a/components/ui/dotted-surface.tsx
+++ b/components/ui/dotted-surface.tsx
@@ -6,12 +6,43 @@ import React, { useEffect, useRef } from "react";
 
 type DottedSurfaceProps = Omit<React.ComponentProps<"div">, "ref">;
 
+function isWebGLAvailable(): boolean {
+  try {
+    const canvas = document.createElement("canvas");
+    return !!(
+      canvas.getContext("webgl") ||
+      canvas.getContext("experimental-webgl")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isLowEndDevice(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    typeof navigator.hardwareConcurrency === "number" &&
+    navigator.hardwareConcurrency < 4
+  );
+}
+
 export function DottedSurface({ className, ...props }: DottedSurfaceProps) {
   const { theme } = useTheme();
 
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!isWebGLAvailable()) {
+      console.warn(
+        "[DottedSurface] WebGL is not available in this browser. Skipping Three.js renderer."
+      );
+      return;
+    }
+
+    if (isLowEndDevice()) {
+      return;
+    }
+
     const container = containerRef.current;
 
     if (!container) {
@@ -19,7 +50,7 @@ export function DottedSurface({ className, ...props }: DottedSurfaceProps) {
     }
 
     let isDisposed = false;
-    let cleanupScene = () => {};
+    let cleanupScene = () => { };
 
     const loadScene = async () => {
       const THREE = await import("three");
@@ -87,7 +118,7 @@ export function DottedSurface({ className, ...props }: DottedSurfaceProps) {
         new THREE.Float32BufferAttribute(colors, 3)
       );
 
-      const material = new THREE.PointsMaterial({
+      const material = new TßHREE.PointsMaterial({
         size: 6,
         vertexColors: true,
         transparent: true,

--- a/components/ui/payeasy-hero.tsx
+++ b/components/ui/payeasy-hero.tsx
@@ -365,7 +365,11 @@ export function PayEasyHero({
               },
             }}
           >
-            {[...programs, ...programs].map((program, index) => (
+            {[...programs, ...programs].map((program, index) => {
+              // #549 — only the first 2 visible cards are loaded eagerly;
+              // all duplicated / off-screen cards use lazy loading.
+              const isEager = index < 2;
+              return (
               <motion.div
                 key={index}
                 whileHover={{ scale: 1.04, y: -8 }}
@@ -378,7 +382,8 @@ export function PayEasyHero({
                   src={program.image}
                   alt={program.title}
                   fill
-                  priority={index === 0}
+                  priority={isEager}
+                  loading={isEager ? "eager" : "lazy"}
                   sizes="(max-width: 640px) 80vw, 320px"
                   className="w-full h-full object-cover"
                 />
@@ -397,7 +402,8 @@ export function PayEasyHero({
                   </h3>
                 </div>
               </motion.div>
-            ))}
+              );
+            })}
           </motion.div>
         </motion.div>
       )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,29 +66,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
@@ -1031,6 +1008,7 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1048,6 +1026,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1138,6 +1117,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1777,6 +1757,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2286,6 +2267,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3030,6 +3012,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3199,6 +3182,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4732,6 +4716,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5878,6 +5863,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6097,6 +6083,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6109,6 +6096,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7128,6 +7116,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7336,6 +7325,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7465,6 +7455,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",


### PR DESCRIPTION
## Perf: WebGL Fallback, Low-End Device Guard, Lazy Carousel Images & Memoized Escrow Computations

### Summary
Four performance improvements shipped together to reduce unnecessary rendering work, improve paint times, and eliminate potential runtime errors in constrained environments.

---

### #547 — WebGL Fallback for DottedSurface

**File:** `components/ui/dotted-surface.tsx`

Added an `isWebGLAvailable()` helper that probes `document.createElement("canvas").getContext("webgl")` before the Three.js renderer is ever initialised. If WebGL is unavailable (e.g. a browser launched with `--disable-webgl`), the component returns an empty `<div>` and emits a single `console.warn` — no uncaught errors, no broken canvas.

Closes #547

---

### #548 — Low-End Device Detection for DottedSurface

**Files:** `components/ui/dotted-surface.tsx`, `components/ui/app-shell.tsx`

Uses `navigator.hardwareConcurrency < 4` as a low-end proxy. Inside `DottedSurface` the Three.js path is skipped entirely on qualifying devices. In `AppShell`, the check is evaluated at module load time: low-end devices receive a lightweight CSS `radial-gradient` background div instead of mounting the Three.js canvas, preventing frame drops before they can occur.

Closes #548

---

### #549 — Lazy Load Carousel Images

**File:** `components/ui/payeasy-hero.tsx`

Only the first 2 carousel cards now use `priority={true}` + `loading="eager"`. All remaining cards — including the duplicated loop copies — are marked `loading="lazy"`, so the browser only fetches those images as they scroll into the viewport instead of blocking the initial paint.

Closes #549

---

### #550 — Memoize Escrow State Computations

**File:** `app/escrow/[contractId]/EscrowDashboardClient.tsx`

Wrapped three derived values in `useMemo` so they only recompute when `contractState` actually changes, not on every wallet-connection or release-phase state update:

- `totalFunded` — sum of all roommate `paidAmount` values
- `fundingPercentage` — percentage of total rent covered
- `roommateStatusMap` — `Map<address, isPaid>` lookup for the roommate table

Closes #550
