### PR TITLE
Revert "feat: SSE transaction stream, contract event log, prefetch ro…

### DIFF
--- a/app/escrow/[contractId]/EscrowDashboardClient.tsx
+++ b/app/escrow/[contractId]/EscrowDashboardClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useMemo } from "react";
 import EscrowStatus from "@/components/escrow/EscrowStatus";
-import EventLog from "@/components/escrow/EventLog";
 import FundingProgress from "@/components/escrow/FundingProgress";
 import MultiSigApproval from "@/components/escrow/MultiSigApproval";
 import RoommateTable from "@/components/escrow/RoommateTable";
@@ -27,13 +26,10 @@ import RefreshIndicator from "@/components/escrow/RefreshIndicator";
 import { useStellar } from "@/context/StellarContext";
 import { claimRefund, stroopsToXlm } from "@/lib/stellar/actions/claimRefund";
 import useContractPolling from "@/hooks/useContractPolling";
-import { useEscrowEvents } from "@/hooks/useEscrowEvents";
 import { buildReleaseXdr, signAndSubmitRelease } from "@/lib/stellar/actions/release";
 import { useToast } from "@/hooks/useToast";
 import CopyButton from "@/components/ui/copy-button";
 import { DeadlineCountdown } from "@/components/escrow/DeadlineCountdown";
-import { rpcServer } from "@/lib/stellar/config";
-import type { SorobanRpcServer } from "@/lib/stellar/events";
 
 interface Props {
   contractId: string;
@@ -51,12 +47,6 @@ export default function EscrowDashboardClient({ contractId }: Props) {
   const { contractState, isLoading, error, refresh } = useContractPolling(contractId);
   const { isConnected, publicKey } = useStellar();
   const toast = useToast();
-
-  // Cast rpcServer to the local SorobanRpcServer interface used by useEscrowEvents.
-  const { events: contractEvents } = useEscrowEvents(contractId, {
-    server: rpcServer as unknown as SorobanRpcServer,
-    intervalMs: 30_000,
-  });
 
   const [releasePhase, setReleasePhase] = useState<ReleasePhase>("idle");
   const [preparedXdr, setPreparedXdr] = useState<string | null>(null);
@@ -350,15 +340,6 @@ export default function EscrowDashboardClient({ contractId }: Props) {
               </div>
 
               <RoommateTable roommates={contractState!.roommates} />
-
-              {/* Contract event log — reverse-chronological, polls every 30 s */}
-              <section className="glass-card p-8">
-                <h2 className="text-lg font-black text-white uppercase tracking-widest mb-6 flex items-center gap-3">
-                  <Activity className="h-5 w-5 text-brand-400" />
-                  Event Log
-                </h2>
-                <EventLog events={contractEvents} />
-              </section>
 
               {/* Contribute Form — visible only to the current roommate if they haven't paid full share */}
               {currentRoommate && !currentRoommate.isPaid && contractState?.status !== "funded" && (

--- a/app/history/HistoryClient.tsx
+++ b/app/history/HistoryClient.tsx
@@ -13,7 +13,7 @@ import {
   type ParsedTransaction,
   type TransactionHistoryPager,
 } from "@/lib/stellar/history";
-import { getNewTransactionsByHash, useHorizonStream } from "@/hooks/useTransactionPolling";
+import useTransactionPolling from "@/hooks/useTransactionPolling";
 import EmptyState from "@/components/ui/empty-state";
 import { History } from "lucide-react";
 
@@ -79,7 +79,6 @@ export default function HistoryClient() {
 
   const pagerRef = useRef<TransactionHistoryPager | null>(null);
   const fadeTimersRef = useRef<Record<string, number>>({});
-  const transactionsRef = useRef<Transaction[]>([]);
 
   const horizonClient = useMemo(() => createHorizonClient(), []);
 
@@ -179,29 +178,19 @@ export default function HistoryClient() {
     }
   }, [hasMore, publicKey]);
 
-  // Keep transactionsRef in sync so the SSE callback never reads a stale closure.
-  useEffect(() => {
-    transactionsRef.current = transactions;
-  }, [transactions]);
-
-  // Subscribe to Horizon SSE stream; prepend new transactions as they arrive.
-  useHorizonStream({
-    accountId: isConnected && publicKey ? publicKey : null,
-    onNewTransaction: () => {
-      void fetchLatestPage()
-        .then((latest) => {
-          const newOnes = getNewTransactionsByHash(transactionsRef.current, latest);
-          if (newOnes.length > 0) {
-            setTransactions((prev) => [...newOnes, ...prev]);
-            markAsNew(newOnes);
-            setIsPollingError(false);
-          }
-        })
-        .catch(() => setIsPollingError(true));
+  useTransactionPolling<Transaction>({
+    enabled: isConnected && Boolean(publicKey),
+    currentTransactions: transactions,
+    fetchLatest: fetchLatestPage,
+    onNewTransactions: (newTransactions) => {
+      setTransactions((prev) => [...newTransactions, ...prev]);
+      markAsNew(newTransactions);
+      setIsPollingError(false);
     },
+    intervalMs: 15_000,
   });
 
-  // Keep updates resilient; unhandled promise rejections do not block the page.
+  // Keep polling resilient; errors do not block the page.
   useEffect(() => {
     const listener = (event: PromiseRejectionEvent) => {
       if (String(event.reason ?? "").toLowerCase().includes("history")) {

--- a/hooks/useTransactionPolling.ts
+++ b/hooks/useTransactionPolling.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 
 export interface HasTxHash {
   txHash: string;
@@ -62,56 +62,4 @@ export default function useTransactionPolling<T extends HasTxHash>({
       window.clearInterval(interval);
     };
   }, [enabled, currentTransactions, fetchLatest, onNewTransactions, intervalMs]);
-}
-
-// ─── Horizon SSE stream ────────────────────────────────────────────────────────
-
-const HORIZON_TESTNET = "https://horizon-testnet.stellar.org";
-
-export interface UseHorizonStreamOptions {
-  /** Stellar account ID to stream transactions for. Pass null to disable. */
-  accountId: string | null;
-  horizonUrl?: string;
-  /** Called whenever Horizon pushes a new transaction event. */
-  onNewTransaction: () => void;
-}
-
-/**
- * Opens a Horizon Server-Sent Events stream for the given account on mount
- * and closes it on unmount. Calls `onNewTransaction` each time a new
- * transaction event arrives without triggering unnecessary re-subscriptions.
- */
-export function useHorizonStream({
-  accountId,
-  horizonUrl = HORIZON_TESTNET,
-  onNewTransaction,
-}: UseHorizonStreamOptions): { isStreaming: boolean } {
-  const [isStreaming, setIsStreaming] = useState(false);
-  const callbackRef = useRef(onNewTransaction);
-
-  // Keep ref current without reopening the stream on every render.
-  useEffect(() => {
-    callbackRef.current = onNewTransaction;
-  });
-
-  useEffect(() => {
-    if (!accountId) {
-      setIsStreaming(false);
-      return;
-    }
-
-    const url = `${horizonUrl}/accounts/${encodeURIComponent(accountId)}/transactions?cursor=now`;
-    const es = new EventSource(url);
-
-    es.onopen = () => setIsStreaming(true);
-    es.onmessage = () => void callbackRef.current();
-    es.onerror = () => setIsStreaming(false);
-
-    return () => {
-      es.close();
-      setIsStreaming(false);
-    };
-  }, [accountId, horizonUrl]);
-
-  return { isStreaming };
 }


### PR DESCRIPTION
closes #555  — Added useHorizonStream to hooks/useTransactionPolling.ts: opens a Horizon SSE EventSource stream for the connected wallet account on mount and closes it on unmount. HistoryClient.tsx is updated to subscribe via useHorizonStream instead of a 15-second setInterval; new transactions are prepended immediately with a "New" badge that fades after 5 s.
closes #557 — lib/stellar/health.ts, hooks/useNetworkStatus.ts, and components/ui/network-indicator.tsx are already in main; Footer.tsx already renders <NetworkIndicator /> (included to formally close the issue).
closes #558  — components/escrow/EventLog.tsx and lib/stellar/events.ts (fetchContractEvents / createContractEventPoller) are already in main. This PR wires them into EscrowDashboardClient.tsx via useEscrowEvents (polling every 30 s), rendering a reverse-chronological event timeline with per-event icons beneath the roommate table.
Test plan
 Open Network panel; hover "Connect Wallet" / "Get Started"; verify /connect and /escrow/create prefetch requests appear.
 Mock Horizon SSE stream in useHorizonStream; verify a new transaction prepends to the list and the "New" badge fades after 5 s.
 Mock getNetworkHealth returning degraded; verify the footer shows an amber dot with correct tooltip.
 Mock getContractEvents returning 3 events; navigate to /escrow/[contractId]; verify all 3 render in reverse-chronological order in the Event Log section.
 closes #551 