### PR TITLE
feat: testnet deploy pipeline, page transitions, nav sign-in, wallet balance

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -229,14 +229,18 @@ jobs:
               '```',
             ].join('\n');
 
-            await github.rest.repos.createReleaseAsset;
-
-            // Post as a release comment (reactions on the release body)
-            await github.rest.issues.createComment({
+            // Append deployment summary to the release body
+            const release = await github.rest.repos.getRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.release.id,
-              body,
+              release_id: context.payload.release.id,
+            });
+
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: context.payload.release.id,
+              body: (release.data.body || '') + '\n\n' + body,
             });
 
             // Also set a step summary

--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -19,6 +19,7 @@ import {
 import Link from "next/link";
 import { getExplorerLink } from "@/lib/stellar/explorer";
 import { useStellar } from "@/context/StellarContext";
+import { useWalletBalance } from "@/hooks/useWalletBalance";
 import { PayEasyLogo } from "@/components/ui/payeasy-logo";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { OnboardingCard } from "@/components/ui/onboarding-card";
@@ -66,6 +67,11 @@ export default function ConnectWalletPage() {
   const [checkingNetwork, setCheckingNetwork] = useState(false);
   const [freighterNetwork, setFreighterNetwork] = useState<"TESTNET" | "MAINNET" | null>(null);
   const [isVersionOutdated, setIsVersionOutdated] = useState(false);
+
+  const {
+    balance,
+    isLoading: isBalanceLoading,
+  } = useWalletBalance(publicKey ?? null, isConnected);
 
   useEffect(() => {
     if (isConnected && publicKey) {
@@ -482,11 +488,11 @@ export default function ConnectWalletPage() {
                   <code className="flex-1 min-w-0 text-sm text-dark-200 bg-dark-950/60 rounded-xl px-4 py-3 font-mono truncate border border-white/5">
                     {publicKey}
                   </code>
-                  <CopyButton 
-                    value={publicKey} 
-                    label="Copy wallet address" 
-                    size={18} 
-                    className="!p-3 rounded-xl glass hover:bg-white/10 transition-colors shrink-0" 
+                  <CopyButton
+                    value={publicKey}
+                    label="Copy wallet address"
+                    size={18}
+                    className="!p-3 rounded-xl glass hover:bg-white/10 transition-colors shrink-0"
                   />
                   <a
                     href={getExplorerLink("account", publicKey)}
@@ -500,6 +506,19 @@ export default function ConnectWalletPage() {
                   </a>
                 </div>
 
+                {/* XLM Balance */}
+                <div className="flex items-center justify-between pt-1 border-t border-white/5">
+                  <span className="text-xs uppercase tracking-widest text-dark-500 font-semibold font-display">
+                    Balance
+                  </span>
+                  {isBalanceLoading ? (
+                    <div className="h-4 w-28 rounded bg-white/10 animate-pulse" />
+                  ) : (
+                    <span className="text-sm font-semibold text-white font-mono">
+                      {balance != null ? `${balance} XLM` : "—"}
+                    </span>
+                  )}
+                </div>
               </div>
 
               {/* Fund testnet */}

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -7,9 +7,11 @@ import { useRouter } from "next/navigation";
 import ConnectWalletButton from "@/components/wallet/ConnectWalletButton";
 import { useActiveSection } from "@/hooks/useActiveSection";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { useStellar } from "@/context/StellarContext";
 
 export default function Navbar() {
   const router = useRouter();
+  const { isConnected } = useStellar();
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -70,17 +72,20 @@ export default function Navbar() {
 
         {/* CTA Buttons */}
         <div className="hidden md:flex items-center gap-3">
-          <a href="#" className="btn-secondary !py-2.5 !px-5 !text-sm !rounded-lg">
-            Sign In
-          </a>
-          <a
-            href="#"
+          <Link
+            href={isConnected ? "/escrow/create" : "/connect"}
+            className="btn-secondary !py-2.5 !px-5 !text-sm !rounded-lg"
+          >
+            {isConnected ? "Dashboard" : "Sign In"}
+          </Link>
+          <Link
+            href="/connect"
             className="btn-primary !py-2.5 !px-5 !text-sm !rounded-lg"
             onMouseEnter={() => router.prefetch("/connect")}
           >
             <Wallet size={16} />
             Connect Wallet
-          </a>
+          </Link>
           <ConnectWalletButton />
           <ThemeToggle />
         </div>
@@ -110,17 +115,22 @@ export default function Navbar() {
               </a>
             ))}
             <div className="h-px bg-white/10 my-2" />
-            <a href="#" className="btn-secondary !justify-center">
-              Sign In
-            </a>
-            <a
-              href="#"
+            <Link
+              href={isConnected ? "/escrow/create" : "/connect"}
+              className="btn-secondary !justify-center"
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              {isConnected ? "Dashboard" : "Sign In"}
+            </Link>
+            <Link
+              href="/connect"
               className="btn-primary !justify-center"
               onMouseEnter={() => router.prefetch("/connect")}
+              onClick={() => setIsMobileMenuOpen(false)}
             >
               <Wallet size={16} />
               Connect Wallet
-            </a>
+            </Link>
             <div className="flex justify-center gap-3">
               <ConnectWalletButton />
               <ThemeToggle />

--- a/components/ui/page-transition.tsx
+++ b/components/ui/page-transition.tsx
@@ -13,7 +13,7 @@ export function PageTransition({ children }: { children: React.ReactNode }) {
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -10 }}
-        transition={{ duration: 0.2 }}
+        transition={{ duration: 0.3 }}
         className="flex-1 w-full flex flex-col"
       >
         {children}

--- a/hooks/useWalletBalance.ts
+++ b/hooks/useWalletBalance.ts
@@ -1,13 +1,15 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { fetchXlmBalance } from "@/lib/stellar/horizon";
+import { getNativeBalance } from "@/lib/stellar/queries";
 
 interface WalletBalanceState {
   balance: string | null;
   isLoading: boolean;
   error: string | null;
 }
+
+const REFRESH_INTERVAL_MS = 60_000;
 
 export function useWalletBalance(publicKey: string | null, enabled = false) {
   const [state, setState] = useState<WalletBalanceState>({
@@ -18,9 +20,9 @@ export function useWalletBalance(publicKey: string | null, enabled = false) {
 
   const fetchBalance = useCallback(async () => {
     if (!publicKey) return;
-    setState({ balance: null, isLoading: true, error: null });
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
     try {
-      const raw = await fetchXlmBalance(publicKey, "testnet");
+      const raw = await getNativeBalance(publicKey);
       const num = parseFloat(raw);
       const formatted = num.toLocaleString("en-US", {
         minimumFractionDigits: 2,
@@ -28,14 +30,17 @@ export function useWalletBalance(publicKey: string | null, enabled = false) {
       });
       setState({ balance: formatted, isLoading: false, error: null });
     } catch {
-      setState({ balance: null, isLoading: false, error: "Failed to load balance" });
+      setState((prev) => ({ ...prev, isLoading: false, error: "Failed to load balance" }));
     }
   }, [publicKey]);
 
   useEffect(() => {
-    if (enabled && publicKey) {
-      fetchBalance();
-    }
+    if (!enabled || !publicKey) return;
+
+    fetchBalance();
+
+    const interval = setInterval(fetchBalance, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
   }, [enabled, publicKey, fetchBalance]);
 
   return { ...state, refetch: fetchBalance };

--- a/lib/stellar/queries.ts
+++ b/lib/stellar/queries.ts
@@ -396,6 +396,20 @@ export async function getAccountBalance(publicKey: string): Promise<number> {
   }
 }
 
+export async function getNativeBalance(publicKey: string): Promise<string> {
+  const { fetchXlmBalance } = await import("./horizon.ts");
+  const { getCurrentNetwork } = await import("./explorer.ts");
+
+  try {
+    return await fetchXlmBalance(publicKey, getCurrentNetwork());
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("not found")) {
+      throw new Error(`Account not found: ${publicKey}`);
+    }
+    throw err;
+  }
+}
+
 // ─── Horizon: fee stats ───────────────────────────────────────────────────────
 
 export interface FeeStats {


### PR DESCRIPTION
## Summary

- closes #440 — Fix `deploy-testnet.yml`: remove dead `createReleaseAsset` statement; replace `issues.createComment` with `repos.getRelease` + `repos.updateRelease` so the deployment summary (contract ID, network, tag, RPC URL, Stellar Expert link) is correctly appended to the GitHub release body on every tagged release.
- closes #475 — Update `PageTransition` fade duration from 200ms → 300ms; `AnimatePresence mode="wait"` and the `app/layout.tsx` wrapper were already correct.
- closes #480 — Wire Navbar **Sign In** to `/connect` via `next/link`; reads `isConnected` from `StellarContext` and renders **Dashboard** (→ `/escrow/create`) when the wallet is already connected — both desktop and mobile menus updated.
- closes #485 — Add `getNativeBalance(publicKey)` to `lib/stellar/queries.ts`; update `useWalletBalance` to use it with 60 s auto-refresh via `setInterval`; display formatted XLM balance (`1,234.56 XLM`) with pulse skeleton while loading in the connected state of `app/connect/page.tsx`.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/deploy-testnet.yml` | Fix dead statement; use `repos.updateRelease` for release summary |
| `components/ui/page-transition.tsx` | Duration 0.2 → 0.3 (300ms) |
| `components/landing/Navbar.tsx` | Sign In → `/connect`; Dashboard when connected |
| `lib/stellar/queries.ts` | Add `getNativeBalance` |
| `hooks/useWalletBalance.ts` | Use `getNativeBalance`; 60 s auto-refresh |
| `app/connect/page.tsx` | Show XLM balance with skeleton in connected state |

## Test plan

- [ ] Tag a release; confirm workflow builds WASM, deploys, and appends the contract ID table to the release body.
- [ ] Navigate between `/` and `/connect`; confirm 300ms fade plays on each transition.
- [ ] Click **Sign In** (disconnected) — navigates to `/connect`.
- [ ] Connect wallet, return to `/`; confirm navbar shows **Dashboard** linking to `/escrow/create`.
- [ ] On `/connect` connected state, confirm XLM balance renders as `1,234.56 XLM`, shows skeleton while loading, and auto-refreshes every 60 s.