### PR TITLE
Refactor wallet dashboard to use FundTestnetButton component and add …

### DIFF
--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useWalletConnection } from "@/hooks/useWalletConnection";
 import { useWallet } from "@/hooks/useWallet";
-import { Copy, Plus, History, Coins, ArrowUpRight, ArrowDownLeft, CheckCircle2, Clock, XCircle, Check } from "lucide-react";
+import { Copy, Plus, History, ArrowUpRight, ArrowDownLeft, CheckCircle2, Clock, XCircle, Check } from "lucide-react";
+import FundTestnetButton from "@/components/wallet/FundTestnetButton";
 
 export default function WalletDashboard() {
   const router = useRouter();
@@ -117,12 +118,7 @@ export default function WalletDashboard() {
           View History
         </button>
         {walletData?.network === "testnet" && (
-          <button
-            className="flex items-center justify-center gap-2 p-4 bg-amber-100 hover:bg-amber-200 dark:bg-amber-900/30 dark:hover:bg-amber-900/50 text-amber-900 dark:text-amber-200 rounded-xl transition-colors font-medium"
-          >
-            <Coins className="w-5 h-5" />
-            Fund Testnet
-          </button>
+          <FundTestnetButton publicKey={walletData?.address ?? ""} />
         )}
       </div>
 

--- a/components/escrow/CreateEscrowForm.tsx
+++ b/components/escrow/CreateEscrowForm.tsx
@@ -434,6 +434,27 @@ export default function CreateEscrowForm({
       <div className="space-y-6">
         {step === 1 ? (
           <>
+            {!contractClient ? (
+              <div className="flex items-start gap-3 rounded-xl border border-amber-400/40 bg-amber-400/10 px-4 py-3 text-sm text-amber-200">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="h-5 w-5 shrink-0 mt-0.5 text-amber-400"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <span>
+                  Demo mode: transactions will not be executed on-chain. Results are simulated only.
+                </span>
+              </div>
+            ) : null}
+
             <div className="space-y-1">
               <label htmlFor="total-rent" className="block text-sm text-dark-400">
                 Total Rent Amount

--- a/lib/stellar/queries.ts
+++ b/lib/stellar/queries.ts
@@ -312,6 +312,98 @@ export interface ContractState {
   }[];
 }
 
+// ─── Basic contract info (for /pay/[contractId]) ─────────────────────────────
+
+export interface ContractBasicInfo {
+  landlord: string;
+  totalRent: string;
+  deadline: string;
+  token: string;
+}
+
+/**
+ * Returns the essential fields needed to render the contribute/pay page,
+ * or `null` when the contract does not exist or its data cannot be read.
+ */
+export async function getContractBasicInfo(
+  contractId: string
+): Promise<ContractBasicInfo | null> {
+  try {
+    const { rpcServer, networkPassphrase } = await import("./config.ts");
+    const {
+      TransactionBuilder,
+      Account,
+      Contract,
+      scValToNative,
+      rpc: rpcHelpers,
+    } = await import("@stellar/stellar-sdk");
+
+    const buildInvocationXdr = ({
+      contractId: cId,
+      method,
+      args = [],
+    }: BuildInvocationParams): string => {
+      const contract = new Contract(cId);
+      const source = new Account(cId, "0");
+      const tx = new TransactionBuilder(source, {
+        fee: "100",
+        networkPassphrase,
+      })
+        .addOperation(contract.call(method, ...(args as xdr.ScVal[])))
+        .setTimeout(60)
+        .build();
+      return tx.toXDR();
+    };
+
+    const ctx: QueryContext = {
+      client: {
+        async simulateTransaction(
+          xdrStr: string
+        ): Promise<SimulateTransactionResponse> {
+          try {
+            const tx = TransactionBuilder.fromXDR(xdrStr, networkPassphrase);
+            const result = await withRetry(() =>
+              rpcServer.simulateTransaction(tx)
+            );
+            if (rpcHelpers.Api.isSimulationError(result)) {
+              return { error: result.error };
+            }
+            let retval: unknown = undefined;
+            if (
+              rpcHelpers.Api.isSimulationSuccess(result) &&
+              result.result?.retval
+            ) {
+              try {
+                retval = scValToNative(result.result.retval);
+              } catch {
+                retval = result.result.retval.toString();
+              }
+            }
+            return { results: retval !== undefined ? [{ retval }] : [] };
+          } catch (err) {
+            throw new ContractQueryError(
+              `Soroban RPC simulation failed: ${String(err)}`
+            );
+          }
+        },
+      },
+      builder: { buildInvocationXdr },
+      contractId,
+    };
+
+    const [landlord, totalRent, deadline, token] = await Promise.all([
+      getLandlord(ctx),
+      getTotal(ctx),
+      getDeadline(ctx),
+      getTokenAddress(ctx),
+    ]);
+
+    return { landlord, totalRent, deadline, token };
+  } catch {
+    return null;
+  }
+}
+
 export async function getContractState(contractId: string): Promise<ContractState> {
   const { rpcServer, networkPassphrase } = await import("./config.ts");
   const { TransactionBuilder, Account, Contract, scValToNative, rpc: rpcHelpers } = await import("@stellar/stellar-sdk");

--- a/lib/stellar/token.ts
+++ b/lib/stellar/token.ts
@@ -1,6 +1,24 @@
-import { Contract, scValToNative, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import {
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  scValToNative,
+  nativeToScVal,
+  xdr,
+  rpc,
+} from "@stellar/stellar-sdk";
 import { getCurrentNetwork, getNetworkConfig } from "./config";
-import { toStellarAmount, fromStellarAmount } from "./format";
+import { toStellarAmount } from "./format";
+
+/**
+ * Thrown when a Soroban operation cannot be completed.
+ */
+export class StellarError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StellarError";
+  }
+}
 
 /**
  * Interaction helper for Stellar Asset Contracts (SAC)
@@ -66,11 +84,61 @@ export class TokenHelper {
   }
 
   /**
-   * Internal helper to invoke read-only methods.
+   * Invokes a read-only SAC method via Soroban RPC simulation.
+   * For state-mutating calls the caller should build a full transaction;
+   * this path is intentionally simulation-only (no signing required).
    */
-  private async invoke(method: string, args: xdr.ScVal[]): Promise<any> {
-    // This is a simplified version. In a real app, you'd use a Soroban RPC client.
-    // For now, we're providing the structure as per requirements.
-    throw new Error("Method not implemented: requires Soroban RPC integration.");
+  private async invoke(method: string, args: xdr.ScVal[]): Promise<xdr.ScVal> {
+    const networkConfig = getNetworkConfig();
+
+    let server: rpc.Server;
+    try {
+      server = new rpc.Server(networkConfig.rpcUrl, { allowHttp: false });
+    } catch (err) {
+      throw new StellarError(
+        `Failed to connect to Soroban RPC at ${networkConfig.rpcUrl}: ${String(err)}`
+      );
+    }
+
+    // Fetch the source account — use the contract address itself as a dummy
+    // source for simulation (read-only calls don't need a real signer).
+    const contractId = (this.contract as any).contractId() as string;
+    let sourceAccount;
+    try {
+      sourceAccount = await server.getAccount(contractId);
+    } catch (err) {
+      throw new StellarError(
+        `Unable to load source account for simulation (${contractId}): ${String(err)}`
+      );
+    }
+
+    const operation = this.contract.call(method, ...args);
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: networkConfig.networkPassphrase,
+    })
+      .addOperation(operation)
+      .setTimeout(60)
+      .build();
+
+    let simResult: rpc.Api.SimulateTransactionResponse;
+    try {
+      simResult = await server.simulateTransaction(tx);
+    } catch (err) {
+      throw new StellarError(`Soroban RPC simulation request failed: ${String(err)}`);
+    }
+
+    if (rpc.Api.isSimulationError(simResult)) {
+      throw new StellarError(`Soroban simulation error in ${method}: ${simResult.error}`);
+    }
+
+    if (!rpc.Api.isSimulationSuccess(simResult) || !simResult.result?.retval) {
+      throw new StellarError(
+        `Soroban simulation for ${method} returned no result`
+      );
+    }
+
+    return simResult.result.retval;
   }
 }


### PR DESCRIPTION
Wire up Fund Testnet button on wallet page
Replaced the inert button with the existing FundTestnetButton component, which handles the Friendbot funding flow and shows loading/success/error feedback. Button only appears on testnet.
closes #653

Show demo mode warning at Step 1 of CreateEscrowForm
Added an amber info banner at the top of Step 1 that appears whenever contractClient is not provided, so users know transactions are simulated before filling out any fields — not just at the final review step.
closes #656

Implement missing getContractBasicInfo to fix /pay/[contractId] crash
Exported getContractBasicInfo(contractId) from lib/stellar/queries.ts. It fetches landlord, total rent, deadline, and token address from Soroban storage, returning null when the contract is not found. The page now renders a "Contract not found" state instead of crashing.
closes #658

Implement TokenHelper.invoke() with real Soroban RPC
Replaced the "Method not implemented" stub with a working simulation-based implementation using rpc.Server from @stellar/stellar-sdk. Throws a descriptive StellarError at each failure point instead of a plain string.
closes #659
