### PR TITLE
fix: dashboard auth bypass, mock data in queries, and ContributeForm prop mismatch

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,46 +2,49 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { getLandlordEscrows, getLandlordStats } from "@/lib/stellar/queries";
+import { getLandlordEscrows, getLandlordStats, type EscrowContract, type LandlordStats } from "@/lib/stellar/queries";
+import { useStellar } from "@/context/StellarContext";
 import EscrowDashboardSkeleton from "@/components/escrow/EscrowDashboardSkeleton";
 import FundingProgress from "@/components/escrow/FundingProgress";
-import DeadlineCountdown from "@/components/escrow/DeadlineCountdown";
+import { DeadlineCountdown } from "@/components/escrow/DeadlineCountdown";
 
 export default function DashboardPage() {
   const router = useRouter();
-  const [escrows, setEscrows] = useState<any[]>([]);
-  const [stats, setStats] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
-  const [connected, setConnected] = useState(true); // Replace with actual auth logic
+  const { isConnected, publicKey, isRestoring } = useStellar();
+  const [escrows, setEscrows] = useState<EscrowContract[]>([]);
+  const [stats, setStats] = useState<LandlordStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (isRestoring) return;
+    if (!isConnected || !publicKey) {
+      router.push("/connect");
+      return;
+    }
+
     async function fetchData() {
       setLoading(true);
-      // TODO: Replace with actual auth check
-      const isConnected = true; // Replace with actual check
-      setConnected(isConnected);
-      if (!isConnected) {
-        router.push("/connect");
-        return;
-      }
+      setError(null);
       try {
         const [escrowsData, statsData] = await Promise.all([
-          getLandlordEscrows(),
-          getLandlordStats(),
+          getLandlordEscrows(publicKey!),
+          getLandlordStats(publicKey!),
         ]);
         setEscrows(escrowsData);
         setStats(statsData);
       } catch (e) {
-        // handle error
+        setError(e instanceof Error ? e.message : "Failed to load dashboard data.");
       } finally {
         setLoading(false);
       }
     }
     fetchData();
-  }, [router]);
+  }, [isConnected, publicKey, isRestoring, router]);
 
-  if (!connected) return null;
-  if (loading) return <EscrowDashboardSkeleton />;
+  if (isRestoring || loading) return <EscrowDashboardSkeleton />;
+  if (!isConnected) return null;
+  if (error) return <div className="p-8 text-center text-red-500">{error}</div>;
 
   return (
     <div className="max-w-5xl mx-auto py-10">
@@ -63,13 +66,13 @@ export default function DashboardPage() {
         {escrows.map((escrow) => (
           <div key={escrow.id} className="bg-dark-900/40 rounded-xl p-6 flex flex-col gap-4">
             <div className="flex justify-between items-center">
-              <div className="font-bold text-lg">{escrow.name}</div>
+              <div className="font-bold text-lg">{escrow.id}</div>
               <button className="btn-primary !py-1.5 !px-4 !text-xs">Release</button>
             </div>
-            <FundingProgress funded={escrow.funded} total={escrow.total} />
+            <FundingProgress totalFunded={escrow.totalFunded} totalRequired={Number(escrow.totalRent)} />
             <div className="flex justify-between text-xs text-dark-500">
-              <div>Roommates: <span className="font-bold text-dark-200">{escrow.roommateCount}</span></div>
-              <div>Days to deadline: <DeadlineCountdown deadline={escrow.deadline} /></div>
+              <div>Status: <span className="font-bold text-dark-200">{escrow.status}</span></div>
+              <div>Deadline: <DeadlineCountdown deadlineEpoch={escrow.deadlineEpoch} /></div>
             </div>
           </div>
         ))}

--- a/components/escrow/ContributeForm.tsx
+++ b/components/escrow/ContributeForm.tsx
@@ -6,26 +6,24 @@ import useFreighter from "@/hooks/useFreighter.ts";
 import TransactionReview from "@/components/wallet/TransactionReview.tsx";
 import { validateContributionAmount } from "./contributeForm.helpers.ts";
 import { buildContributeXdr, signAndSubmitContribute } from "@/lib/stellar/actions/contribute";
+import type { ContractBasicInfo } from "@/lib/stellar/queries";
 
 type ContributePhase = "idle" | "building" | "review" | "submitting";
 
 interface ContributeFormProps {
-  escrowId: string;
-  expectedShare: string;
-  remainingBalance: string;
+  contractId: string;
+  contractInfo: ContractBasicInfo;
   onSuccess?: (txHash: string) => void;
 }
 
-/**
- * A form for roommates to contribute their share to an escrow agreement.
- * Includes validation and integrates with the Freighter wallet.
- */
 export default function ContributeForm({
-  escrowId,
-  expectedShare,
-  remainingBalance,
+  contractId,
+  contractInfo,
   onSuccess,
 }: ContributeFormProps) {
+  const escrowId = contractId;
+  const expectedShare = contractInfo.totalRent;
+  const remainingBalance = contractInfo.totalRent;
   const { isConnected, connect, publicKey } = useFreighter();
   
   const [amount, setAmount] = useState(expectedShare);

--- a/lib/stellar/queries.ts
+++ b/lib/stellar/queries.ts
@@ -1,34 +1,85 @@
-// Returns all escrows for a landlord (stub, replace with real implementation)
-export async function getLandlordEscrows(): Promise<any[]> {
-  // TODO: Replace with actual Soroban RPC call and landlord address filtering
-  return [
-    {
-      id: "escrow1",
-      name: "Apartment 1",
-      funded: 500,
-      total: 1000,
-      roommateCount: 3,
-      deadline: Date.now() + 86400000 * 10,
-    },
-    {
-      id: "escrow2",
-      name: "Apartment 2",
-      funded: 1200,
-      total: 1200,
-      roommateCount: 2,
-      deadline: Date.now() + 86400000 * 5,
-    },
-  ];
+export interface EscrowContract {
+  id: string;
+  landlord: string;
+  totalRent: string;
+  deadline: string;
+  deadlineEpoch: number;
+  status: "active" | "funded" | "released" | "expired";
+  totalFunded: number;
 }
 
-// Returns landlord dashboard stats (stub, replace with real implementation)
-export async function getLandlordStats(): Promise<any> {
-  // TODO: Replace with actual Soroban RPC call and landlord address filtering
-  return {
-    totalEscrowed: 1700,
-    activeEscrows: 2,
-    totalReleased: 800,
-  };
+export interface LandlordStats {
+  totalEscrowed: number;
+  activeEscrows: number;
+  totalReleased: number;
+}
+
+export async function getLandlordEscrows(address: string): Promise<EscrowContract[]> {
+  const { createHorizonClient, fetchTransactionHistory } = await import("./history");
+  const client = createHorizonClient();
+
+  const contractIds = new Set<string>();
+  let cursor: string | undefined;
+
+  for (let page = 0; page < 10; page++) {
+    const result = await fetchTransactionHistory({
+      client,
+      accountId: address,
+      cursor,
+      limit: 50,
+      includeOperations: true,
+    });
+
+    for (const tx of result.transactions) {
+      for (const op of tx.operations) {
+        if (op.type === "invoke_host_function" && op.contractId) {
+          contractIds.add(op.contractId);
+        }
+      }
+    }
+
+    if (!result.nextCursor || result.transactions.length === 0) break;
+    cursor = result.nextCursor;
+  }
+
+  const escrows: EscrowContract[] = [];
+
+  await Promise.all(
+    Array.from(contractIds).map(async (contractId) => {
+      try {
+        const state = await getContractState(contractId);
+        if (state.landlord === address) {
+          escrows.push({
+            id: state.id,
+            landlord: state.landlord,
+            totalRent: state.totalRent,
+            deadline: state.deadline,
+            deadlineEpoch: state.deadlineEpoch,
+            status: state.status,
+            totalFunded: state.totalFunded,
+          });
+        }
+      } catch {
+        // not an escrow contract or contract unavailable, skip
+      }
+    })
+  );
+
+  return escrows;
+}
+
+export async function getLandlordStats(address: string): Promise<LandlordStats> {
+  const escrows = await getLandlordEscrows(address);
+
+  const totalEscrowed = escrows.reduce((sum, e) => sum + Number(e.totalRent), 0);
+  const activeEscrows = escrows.filter(
+    (e) => e.status === "active" || e.status === "funded"
+  ).length;
+  const totalReleased = escrows
+    .filter((e) => e.status === "released")
+    .reduce((sum, e) => sum + Number(e.totalRent), 0);
+
+  return { totalEscrowed, activeEscrows, totalReleased };
 }
 import type { xdr } from "@stellar/stellar-sdk";
 import { withRetry } from "./retry.ts";


### PR DESCRIPTION


closes #661
closes #662
closes #663
closes #664

## Summary

### #661 — Dashboard hardcoded auth bypass
`app/dashboard/page.tsx` previously set `connected = true` unconditionally, meaning
any unauthenticated visitor could view the dashboard. The page now calls `useStellar()`
from `StellarContext` to read the real `isConnected`, `publicKey`, and `isRestoring`
values. While `isRestoring` is true the skeleton is shown. Once context has settled,
any unauthenticated user is redirected to `/connect`. The empty catch block is removed
and errors are surfaced in the UI.

The escrow card rendering is also corrected to use the typed fields from `EscrowContract`
(`totalFunded`/`totalRent` for `FundingProgress`, `deadlineEpoch` for `DeadlineCountdown`)
rather than the old mock field names.

### #662 — getLandlordEscrows returns real data
The mock implementation is replaced with a real lookup:
1. Horizon transaction history is paged for the landlord address (up to 10 pages × 50
   transactions) and all `invoke_host_function` contract IDs are collected.
2. `getContractState` is called concurrently on each candidate contract.
3. Only contracts whose `landlord` field matches the supplied address are returned.

A typed `EscrowContract` interface is introduced so callers no longer receive `any[]`.

### #663 — getLandlordStats derived from real escrow data
The stubbed zeros are replaced by aggregating `getLandlordEscrows`:
- `totalEscrowed` — sum of `Number(totalRent)` across all escrows
- `activeEscrows` — count where `status` is `"active"` or `"funded"`
- `totalReleased` — sum of `Number(totalRent)` for escrows with `status === "released"`

A typed `LandlordStats` interface is introduced.

### #664 — ContributeForm prop mismatch
`app/pay/[contractId]/page.tsx` passed `contractId` and `contractInfo` (a
`ContractBasicInfo` object) but `ContributeForm` declared `{ escrowId, expectedShare,
remainingBalance }`. This caused a TypeScript error and runtime failure.

`ContributeForm` now accepts `{ contractId, contractInfo: ContractBasicInfo }` and
derives `escrowId`, `expectedShare`, and `remainingBalance` internally from those values.
The page required no further changes.

## Testing

- Render dashboard without a connected wallet: verify redirect to `/connect`.
- Mock Soroban returning 2 contracts for a landlord address: verify only those 2 appear.
- Mock 3 escrows (2 active, 1 released): verify `totalEscrowed`, `activeEscrows`,
  and `totalReleased` totals are correct.
- Render `ContributeForm` with `contractId` and a `ContractBasicInfo` object: verify
  the amount field pre-populates with `totalRent` and the balance display is correct.
