### PR TITLE
chore: enforce consistent error handling pattern via ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,13 @@
 module.exports = {
   extends: ["next/core-web-vitals"],
+  plugins: ["@typescript-eslint"],
+  rules: {
+    // Enforce consistent error handling: disallow empty blocks (incl. empty
+    // catch blocks) so errors are never silently swallowed.
+    "no-empty": ["error", { allowEmptyCatch: false }],
+    // Discourage `any`; prefer precise types or `unknown` for caught errors.
+    "@typescript-eslint/no-explicit-any": "warn",
+  },
   overrides: [
     {
       files: ["lib/stellar/**/*.{js,jsx,ts,tsx}"],

--- a/app/api/user/export/route.ts
+++ b/app/api/user/export/route.ts
@@ -1,10 +1,10 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { verifyToken } from "@/lib/auth/jwt";
 import { findUserById, getNotificationPreferences } from "@/lib/auth/users";
 
-async function resolveUserId(request: Request): Promise<string | null> {
+async function resolveUserId(request: NextRequest): Promise<string | null> {
   let token: string | undefined;
-  const cookies = (request as any).cookies;
+  const cookies = request.cookies;
   if (cookies?.get) {
     token = cookies.get("auth_token")?.value;
   }
@@ -21,7 +21,7 @@ async function resolveUserId(request: Request): Promise<string | null> {
   return null;
 }
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   try {
     const userId = await resolveUserId(request);
     

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,15 +2,20 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { getLandlordEscrows, getLandlordStats } from "@/lib/stellar/queries";
+import {
+  getLandlordEscrows,
+  getLandlordStats,
+  type EscrowContract,
+  type LandlordStats,
+} from "@/lib/stellar/queries";
 import EscrowDashboardSkeleton from "@/components/escrow/EscrowDashboardSkeleton";
 import FundingProgress from "@/components/escrow/FundingProgress";
 import DeadlineCountdown from "@/components/escrow/DeadlineCountdown";
 
 export default function DashboardPage() {
   const router = useRouter();
-  const [escrows, setEscrows] = useState<any[]>([]);
-  const [stats, setStats] = useState<any>(null);
+  const [escrows, setEscrows] = useState<EscrowContract[]>([]);
+  const [stats, setStats] = useState<LandlordStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [connected, setConnected] = useState(true); // Replace with actual auth logic
 

--- a/app/pay/[contractId]/page.tsx
+++ b/app/pay/[contractId]/page.tsx
@@ -4,13 +4,18 @@ import { useRouter } from "next/navigation";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import ContributeForm from "@/components/escrow/ContributeForm";
-import { getContractBasicInfo } from "@/lib/stellar/queries";
+import {
+  getContractBasicInfo,
+  type ContractBasicInfo,
+} from "@/lib/stellar/queries";
 
 export default function PayContractPage() {
   const router = useRouter();
   const params = useParams();
   const { contractId } = params as { contractId: string };
-  const [contractInfo, setContractInfo] = useState<any>(null);
+  const [contractInfo, setContractInfo] = useState<ContractBasicInfo | null>(
+    null
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,7 +26,7 @@ export default function PayContractPage() {
       try {
         const info = await getContractBasicInfo(contractId);
         setContractInfo(info);
-      } catch (e: any) {
+      } catch {
         setError("Failed to load contract info");
       } finally {
         setLoading(false);

--- a/lib/auth/db-adapter.ts
+++ b/lib/auth/db-adapter.ts
@@ -39,8 +39,8 @@ export class FileDataStore implements DataStore {
         // Try to create lock file exclusively
         await fs.open(this.lockFile, "wx");
         return;
-      } catch (err: any) {
-        if (err.code !== "EEXIST") throw err;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
 
         // Check lock timeout
         if (Date.now() - startTime > this.lockTimeout) {
@@ -59,9 +59,9 @@ export class FileDataStore implements DataStore {
     const fs = require("fs").promises;
     try {
       await fs.unlink(this.lockFile);
-    } catch (err: any) {
+    } catch (err) {
       // Lock file already removed or doesn't exist
-      if (err.code !== "ENOENT") throw err;
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     }
   }
 
@@ -136,13 +136,41 @@ export class FileDataStore implements DataStore {
 }
 
 /**
+ * Raw user record as returned by the Prisma client.
+ */
+interface PrismaUserRecord {
+  id: string;
+  email: string;
+  name: string;
+  passwordHash: string;
+  createdAt: Date;
+}
+
+/**
+ * Minimal structural type describing the subset of the Prisma client this
+ * adapter relies on. Avoids a hard dependency on the generated client types
+ * (which are only available when Prisma is installed).
+ */
+interface PrismaClientLike {
+  user: {
+    findUnique(args: {
+      where: { email?: string; id?: string };
+    }): Promise<PrismaUserRecord | null>;
+    create(args: {
+      data: { email: string; name: string; passwordHash: string };
+    }): Promise<PrismaUserRecord>;
+    findMany(): Promise<PrismaUserRecord[]>;
+  };
+}
+
+/**
  * Database-backed DataStore implementation using Prisma.
  * Suitable for production deployments.
  */
 export class DatabaseDataStore implements DataStore {
-  private prisma: any;
+  private prisma: PrismaClientLike;
 
-  constructor(prismaClient: any) {
+  constructor(prismaClient: PrismaClientLike) {
     this.prisma = prismaClient;
   }
 
@@ -181,10 +209,10 @@ export class DatabaseDataStore implements DataStore {
 
   async getAllUsers(): Promise<StoredUser[]> {
     const users = await this.prisma.user.findMany();
-    return users.map((user: any) => this.mapPrismaUserToStoredUser(user));
+    return users.map((user) => this.mapPrismaUserToStoredUser(user));
   }
 
-  private mapPrismaUserToStoredUser(user: any): StoredUser {
+  private mapPrismaUserToStoredUser(user: PrismaUserRecord): StoredUser {
     return {
       id: user.id,
       email: user.email,

--- a/lib/auth/rate-limit.ts
+++ b/lib/auth/rate-limit.ts
@@ -109,13 +109,34 @@ export class InMemoryRateLimiter {
 }
 
 /**
+ * Minimal structural type describing the subset of the Redis (Upstash) client
+ * used by the rate limiter. Keeps the limiter decoupled from a specific client.
+ */
+interface RedisLike {
+  zcount(key: string, min: number, max: string): Promise<number>;
+  zadd(
+    key: string,
+    member: { score: number; member: string }
+  ): Promise<unknown>;
+  expire(key: string, seconds: number): Promise<unknown>;
+  zrange(
+    key: string,
+    start: number,
+    stop: number,
+    opts: { withScores: boolean }
+  ): Promise<Array<{ score: number; member?: string }>>;
+  del(...keys: string[]): Promise<unknown>;
+  keys(pattern: string): Promise<string[]>;
+}
+
+/**
  * Redis-backed rate limiter for distributed deployments.
  * Uses Upstash Redis for serverless environments.
  */
 export class RedisRateLimiter {
-  private redis: any;
+  private redis: RedisLike;
 
-  constructor(redisClient: any, private config: RateLimitConfig) {
+  constructor(redisClient: RedisLike, private config: RateLimitConfig) {
     this.redis = redisClient;
   }
 

--- a/lib/auth/users.ts
+++ b/lib/auth/users.ts
@@ -88,14 +88,15 @@ export function getNotificationPreferences(userId: string): NotificationPreferen
   return user?.notificationPreferences || DEFAULT_NOTIFICATIONS;
 }
 
-export function isValidNotificationPatch(body: any): boolean {
+export function isValidNotificationPatch(body: unknown): boolean {
   if (!body || typeof body !== 'object') return false;
 
   const validKeys = ['marketingEmails', 'securityAlerts', 'pushNotifications'];
+  const patch = body as Record<string, unknown>;
 
-  for (const key of Object.keys(body)) {
+  for (const key of Object.keys(patch)) {
     // If the key isn't allowed, or the value isn't a boolean, reject it
-    if (!validKeys.includes(key) || typeof body[key] !== 'boolean') {
+    if (!validKeys.includes(key) || typeof patch[key] !== 'boolean') {
       return false;
     }
   }

--- a/lib/exportCsv.ts
+++ b/lib/exportCsv.ts
@@ -27,7 +27,7 @@ export function exportTransactionsToCsv(transactions: Transaction[]) {
       escapeCsv(date),
       escapeCsv(tx.type.toUpperCase()),
       escapeCsv(tx.amount),
-      escapeCsv((tx as any).fee || "N/A"), // Fallback if fee is not in type
+      escapeCsv((tx as { fee?: string }).fee || "N/A"), // Fallback if fee is not in type
       escapeCsv(tx.txHash),
       escapeCsv(tx.status.toUpperCase()),
     ].join(",");

--- a/lib/listingsCache.ts
+++ b/lib/listingsCache.ts
@@ -3,9 +3,12 @@ import redis from '../redis';
 const LISTINGS_ALL_KEY = (page: number) => `listings:all:page:${page}`;
 const LISTING_DETAIL_KEY = (id: string) => `listings:detail:${id}`;
 
-export async function getCachedListings(page: number, fetchFn: () => Promise<any[]>) {
+export async function getCachedListings<T>(
+  page: number,
+  fetchFn: () => Promise<T[]>
+): Promise<T[]> {
   const key = LISTINGS_ALL_KEY(page);
-  let listings = await redis.get(key);
+  let listings = (await redis.get(key)) as T[] | null;
   if (!listings) {
     listings = await fetchFn();
     await redis.set(key, listings, { ex: 900 }); // 15 min TTL
@@ -13,9 +16,12 @@ export async function getCachedListings(page: number, fetchFn: () => Promise<any
   return listings;
 }
 
-export async function getCachedListingDetail(id: string, fetchFn: () => Promise<any>) {
+export async function getCachedListingDetail<T>(
+  id: string,
+  fetchFn: () => Promise<T>
+): Promise<T> {
   const key = LISTING_DETAIL_KEY(id);
-  let detail = await redis.get(key);
+  let detail = (await redis.get(key)) as T | null;
   if (!detail) {
     detail = await fetchFn();
     await redis.set(key, detail, { ex: 3600 }); // 1 hour TTL

--- a/lib/stellar/actions/release.test.ts
+++ b/lib/stellar/actions/release.test.ts
@@ -11,16 +11,17 @@ test("assertFullyFunded against Stellar testnet - throws on non-existent contrac
   try {
     await assertFullyFunded(fakeContractId, fakeLandlordAddress);
     assert.fail("Should have thrown an error");
-  } catch (err: any) {
+  } catch (err) {
     // Expected to throw because the contract/address is fake.
     // Either the SDK rejects the malformed address up-front, or we reach simulation
     // and the network rejects the missing contract.
+    const message = err instanceof Error ? err.message : String(err);
     assert.ok(
-      err.message.includes("Simulation failed") ||
-      err.message.includes("Simulation request failed") ||
-      err.message.includes("invalid") ||
+      message.includes("Simulation failed") ||
+      message.includes("Simulation request failed") ||
+      message.includes("invalid") ||
       err instanceof EscrowNotFundedError,
-      `Unexpected error: ${err.message}`
+      `Unexpected error: ${message}`
     );
   }
 });

--- a/lib/stellar/errors.ts
+++ b/lib/stellar/errors.ts
@@ -173,7 +173,7 @@ const ERROR_MAPPINGS: Record<number | string, UserFriendlyError> = {
  * Translates a raw error from Stellar, Soroban, or Freighter into a user-friendly message.
  * @param error The raw error object or message string.
  */
-export function translateStellarError(error: any): UserFriendlyError {
+export function translateStellarError(error: unknown): UserFriendlyError {
   let errorKey: string | number = "UNKNOWN";
 
   if (typeof error === "string") {
@@ -185,11 +185,12 @@ export function translateStellarError(error: any): UserFriendlyError {
     else errorKey = error;
   } else if (error && typeof error === "object") {
     // Handle Soroban contract error codes (e.g., from simulation or resultXdr)
-    if (typeof error.code === "number") {
-      errorKey = error.code;
-    } else if (error.message) {
+    const err = error as { code?: unknown; message?: unknown };
+    if (typeof err.code === "number") {
+      errorKey = err.code;
+    } else if (typeof err.message === "string") {
       // Handle known error message substrings
-      const msg = error.message.toLowerCase();
+      const msg = err.message.toLowerCase();
       if (msg.includes("timeout")) errorKey = "TIMEOUT";
       else if (msg.includes("unavailable") || msg.includes("fetch")) errorKey = "NODE_UNAVAILABLE";
       else if (msg.includes("declined") || msg.includes("reject")) errorKey = "User declined";
@@ -207,6 +208,6 @@ export function translateStellarError(error: any): UserFriendlyError {
   return {
     type: StellarErrorType.UNKNOWN,
     message: "An unexpected Stellar error occurred.",
-    guidance: typeof error?.message === "string" ? error.message : "If the problem persists, please contact support with details of the action you were performing.",
+    guidance: typeof (error as { message?: unknown })?.message === "string" ? (error as { message: string }).message : "If the problem persists, please contact support with details of the action you were performing.",
   };
 }

--- a/lib/stellar/token.ts
+++ b/lib/stellar/token.ts
@@ -102,7 +102,9 @@ export class TokenHelper {
 
     // Fetch the source account — use the contract address itself as a dummy
     // source for simulation (read-only calls don't need a real signer).
-    const contractId = (this.contract as any).contractId() as string;
+    const contractId = (
+      this.contract as { contractId(): string }
+    ).contractId();
     let sourceAccount;
     try {
       sourceAccount = await server.getAccount(contractId);


### PR DESCRIPTION
## Summary

Enforces a consistent error-handling pattern across the codebase via ESLint, as requested in #199.

### ESLint rules added (`.eslintrc.js`)
- **`no-empty`** (`error`, `allowEmptyCatch: false`) — empty blocks, including empty `catch` blocks, are no longer allowed, so errors can't be silently swallowed.
- **`@typescript-eslint/no-explicit-any`** (`warn`) — discourages `any` in favour of precise types or `unknown` for caught errors.

The `@typescript-eslint` plugin is also registered so the rule actually resolves (without it, ESLint reports "Definition for rule … was not found").

### Violations fixed
All `no-explicit-any` violations surfaced by the new rule were resolved (no suppressions):

- `app/api/user/export/route.ts` — typed the request as `NextRequest` instead of `(request as any)`.
- `app/dashboard/page.tsx` — typed state with `EscrowContract` / `LandlordStats`.
- `app/pay/[contractId]/page.tsx` — typed state with `ContractBasicInfo`; narrowed an unused `catch (e: any)` to `catch`.
- `lib/auth/db-adapter.ts` — replaced `any` with a minimal `PrismaClientLike` / `PrismaUserRecord` structural type; narrowed caught errors to `NodeJS.ErrnoException`.
- `lib/auth/rate-limit.ts` — replaced `any` with a minimal `RedisLike` structural type.
- `lib/auth/users.ts` — `isValidNotificationPatch` now takes `unknown` and narrows internally.
- `lib/exportCsv.ts` — `tx as any` → precise inline type.
- `lib/listingsCache.ts` — cache helpers are now generic instead of returning `any`.
- `lib/stellar/errors.ts` — `translateStellarError` now takes `unknown` and narrows.
- `lib/stellar/token.ts` — `contract as any` → precise inline type.
- `lib/stellar/actions/release.test.ts` — narrowed `catch (err: any)` to `unknown` with an `instanceof Error` guard.

## Verification

- `npm run lint` reports **zero `no-empty` violations** and **zero `@typescript-eslint/no-explicit-any` warnings**.
- The codebase currently has no empty `catch` blocks, so `no-empty` adds forward-looking enforcement.
- `tsc --noEmit` shows no new type errors introduced by these changes.

## Note on pre-existing lint failures (out of scope)

`npm run lint` does not yet exit `0` because of **pre-existing breakage already on `main`**, unrelated to error handling:

- `app/escrow/[contractId]/EscrowDashboardClient.tsx` uses `Clock`, `CheckCircle2`, `RefreshCcw` in JSX without importing them (`react/jsx-no-undef`).
- `components/history/TransactionList.tsx` has a corrupted `interface`/component body (an in-progress sort-order feature).
- Several `*.test.ts` files were committed with escaped quotes (`from \"vitest\"`), causing parse errors.

These are intentionally left untouched here to keep this PR scoped to #199 and avoid colliding with the in-flight work that owns those files.

Closes #696 
