### PR TITLE
chore: add pre-commit hook for type check and lint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Husky hooks are executed through `sh`; force LF so they run on every platform
+# regardless of the local core.autocrlf setting.
+.husky/pre-commit text eol=lf
+.husky/typecheck-staged.mjs text eol=lf

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.husky/typecheck-staged.mjs
+++ b/.husky/typecheck-staged.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Type-checks the staged TypeScript files passed as CLI arguments.
+ *
+ * lint-staged invokes this as `node .husky/typecheck-staged.mjs <files...>`.
+ * We can't run a plain `tsc --noEmit <files>` because that ignores the project
+ * tsconfig (paths, lib, strict, etc.). Instead we generate a temporary config
+ * that extends the project's tsconfig.json but only includes the staged files,
+ * so the commit is validated quickly and in isolation.
+ *
+ * tsc is launched through the current Node binary (not the `.cmd`/`.bin`
+ * shim) so this behaves identically on Windows, macOS and Linux.
+ */
+import { spawnSync } from "node:child_process";
+import { writeFileSync, unlinkSync, existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+
+const files = process.argv.slice(2).filter((file) => /\.(ts|tsx)$/.test(file));
+
+// Nothing to check (e.g. only non-TS files were staged).
+if (files.length === 0) {
+  process.exit(0);
+}
+
+const root = process.cwd();
+const tmpConfigPath = path.join(
+  root,
+  `tsconfig.staged-${randomBytes(4).toString("hex")}.json`
+);
+
+writeFileSync(
+  tmpConfigPath,
+  JSON.stringify(
+    {
+      extends: "./tsconfig.json",
+      // noEmit keeps it a pure type check; incremental is disabled so we never
+      // clobber the project's tsbuildinfo cache from a throwaway config.
+      compilerOptions: { noEmit: true, skipLibCheck: true, incremental: false },
+      files: files.map((file) =>
+        path.relative(root, path.resolve(file)).split(path.sep).join("/")
+      ),
+      include: [],
+    },
+    null,
+    2
+  )
+);
+
+let exitCode = 1;
+try {
+  const require = createRequire(import.meta.url);
+  const tscBin = require.resolve("typescript/bin/tsc");
+  const result = spawnSync(process.execPath, [tscBin, "-p", tmpConfigPath], {
+    stdio: "inherit",
+  });
+  exitCode = result.status ?? 1;
+} finally {
+  if (existsSync(tmpConfigPath)) {
+    unlinkSync(tmpConfigPath);
+  }
+}
+
+process.exit(exitCode);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,14 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "**/*.{ts,tsx}": [
+      "eslint",
+      "node .husky/typecheck-staged.mjs"
+    ]
   },
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",
@@ -44,9 +51,11 @@
     "autoprefixer": "^10.4.0",
     "eslint": "^8.0.0",
     "eslint-config-next": "^14.2.0",
+    "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "jsdom": "^27.0.1",
+    "lint-staged": "^17.0.5",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Summary

Adds a pre-commit hook so TypeScript errors and ESLint violations are caught before they reach the repository, as requested in #200.

### How it works
- **husky** manages the git `pre-commit` hook and is installed automatically via the `prepare` script (`"prepare": "husky"`), so the hook activates on `npm install`.
- **lint-staged** runs tasks only against staged `.ts` / `.tsx` files:
  ```json
  "lint-staged": {
    "**/*.{ts,tsx}": [
      "eslint",
      "node .husky/typecheck-staged.mjs"
    ]
  }
  ```
- **`.husky/pre-commit`** runs `npx lint-staged`.
- **`.husky/typecheck-staged.mjs`** type-checks the staged files by generating a temporary tsconfig that `extends` the project `tsconfig.json` but only `files` the staged ones, then runs `tsc --noEmit -p <temp>`.

### Why a helper script instead of `tsc-files`
- A plain `tsc --noEmit <files>` ignores the project tsconfig (paths, lib, strict). A whole-project `tsc --noEmit` can't be wired through `package.json` lint-staged (it rejects mixing `-p` with file args) and would also be blocked by unrelated pre-existing errors elsewhere in the tree.
- `tsc-files` looked like a fit, but on Windows it spawns `tsc.cmd` directly, which fails silently under git's `sh` and lets bad commits through. The helper launches `tsc` through the current **Node** binary (`process.execPath`), so it behaves identically on Windows, macOS and Linux.
- Checking only the staged files keeps the hook fast and scoped to the commit.

### Notes
- The helper lives in `.husky/` because the repo's `.gitignore` ignores `scripts/`.
- `.gitattributes` pins the hook scripts to `LF` so they run under `sh` regardless of the local `core.autocrlf` setting.

## Verification

Tested locally on Windows:

- **Staged file with a deliberate type error → commit rejected** with a clear message:
  ```
  ✖ node .husky/typecheck-staged.mjs:
  __pc_bad__.ts(1,14): error TS2322: Type 'string' is not assignable to type 'number'.
  husky - pre-commit script failed (code 1)
  ```
- A clean staged `.ts` file commits successfully.
- ESLint also runs on staged files and blocks on lint errors.
- Cold run (incremental cache cleared) completes in ~5s — well under the 30s budget.

Closes #697 
