### PR TITLE
feat: share modal with QR, escrow templates, dispute flag, property

### DIFF
--- a/app/api/disputes/route.ts
+++ b/app/api/disputes/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface DisputeRecord {
+  contractId: string;
+  roommateAddress: string;
+  flaggedAt: number;
+}
+
+// In-memory store — resets on server restart, sufficient for demo/testnet use.
+const disputes = new Map<string, DisputeRecord[]>();
+
+export async function POST(request: NextRequest) {
+  let body: { contractId?: string; roommateAddress?: string };
+
+  try {
+    body = (await request.json()) as {
+      contractId?: string;
+      roommateAddress?: string;
+    };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const { contractId, roommateAddress } = body;
+
+  if (!contractId || !roommateAddress) {
+    return NextResponse.json(
+      { error: "contractId and roommateAddress are required." },
+      { status: 400 }
+    );
+  }
+
+  const record: DisputeRecord = {
+    contractId,
+    roommateAddress,
+    flaggedAt: Date.now(),
+  };
+
+  const existing = disputes.get(contractId) ?? [];
+  disputes.set(contractId, [...existing, record]);
+
+  return NextResponse.json({ success: true, record }, { status: 201 });
+}
+
+export async function GET(request: NextRequest) {
+  const contractId = request.nextUrl.searchParams.get("contractId");
+
+  if (!contractId) {
+    return NextResponse.json(
+      { error: "contractId query parameter is required." },
+      { status: 400 }
+    );
+  }
+
+  const records = disputes.get(contractId) ?? [];
+  return NextResponse.json({ disputes: records });
+}

--- a/app/escrow/[contractId]/EscrowDashboardClient.tsx
+++ b/app/escrow/[contractId]/EscrowDashboardClient.tsx
@@ -18,6 +18,7 @@ import {
   Loader2,
   ArrowUpRight,
   RotateCcw,
+  Share2,
 } from "lucide-react";
 import Link from "next/link";
 import { getExplorerLink } from "@/lib/stellar/explorer";
@@ -30,6 +31,8 @@ import { buildReleaseXdr, signAndSubmitRelease } from "@/lib/stellar/actions/rel
 import { useToast } from "@/hooks/useToast";
 import CopyButton from "@/components/ui/copy-button";
 import { DeadlineCountdown } from "@/components/escrow/DeadlineCountdown";
+import ShareEscrowModal from "@/components/escrow/ShareEscrowModal";
+import DisputeFlag from "@/components/escrow/DisputeFlag";
 
 interface Props {
   contractId: string;
@@ -51,6 +54,7 @@ export default function EscrowDashboardClient({ contractId }: Props) {
   const [preparedXdr, setPreparedXdr] = useState<string | null>(null);
   const [releaseError, setReleaseError] = useState<string | null>(null);
   const [isClaimingRefund, setIsClaimingRefund] = useState(false);
+  const [showShareModal, setShowShareModal] = useState(false);
 
   const isLandlord =
     isConnected &&
@@ -96,6 +100,12 @@ export default function EscrowDashboardClient({ contractId }: Props) {
   const hasNonZeroPaid =
     currentRoommate != null && BigInt(currentRoommate.paidAmount) > BigInt(0);
   const showClaimRefundButton = isDeadlinePassed && isNotFullyFunded && hasNonZeroPaid;
+
+  const showDisputeFlag =
+    !isLandlord &&
+    currentRoommate !== undefined &&
+    contractState?.status === "funded" &&
+    isDeadlinePassed;
 
   async function handleReleaseFunds() {
     if (!contractState) return;
@@ -171,6 +181,12 @@ export default function EscrowDashboardClient({ contractId }: Props) {
     <main id="main-content" aria-label="Escrow Dashboard" className="min-h-screen pt-32 pb-24 relative overflow-hidden bg-[#07070a]">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(92,124,250,0.1),transparent_50%)] pointer-events-none" />
       <div className="mesh-gradient opacity-30 mix-blend-screen pointer-events-none fixed inset-0 saturate-150" />
+
+      <ShareEscrowModal
+        contractId={contractId}
+        isOpen={showShareModal}
+        onClose={() => setShowShareModal(false)}
+      />
 
       {/* TransactionReview modal overlay */}
       {(releasePhase === "review" || releasePhase === "submitting") && preparedXdr && (
@@ -284,7 +300,7 @@ export default function EscrowDashboardClient({ contractId }: Props) {
                   status={contractState!.status}
                 />
 
-                {/* Release Funds — landlord only */}
+                {/* Release Funds + Share — landlord only */}
                 {isLandlord && (
                   <div className="flex flex-col gap-3">
                     {releaseError && (
@@ -293,23 +309,32 @@ export default function EscrowDashboardClient({ contractId }: Props) {
                         {releaseError}
                       </div>
                     )}
-                    <button
-                      onClick={() => void handleReleaseFunds()}
-                      disabled={releasePhase !== "idle"}
-                      className="inline-flex items-center gap-2 w-full sm:w-auto justify-center btn-primary !py-3 !px-6 !rounded-xl font-black uppercase tracking-widest shadow-lg shadow-brand-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {releasePhase === "building" ? (
-                        <>
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          Preparing...
-                        </>
-                      ) : (
-                        <>
-                          <ArrowUpRight className="h-4 w-4" />
-                          Release Funds
-                        </>
-                      )}
-                    </button>
+                    <div className="flex flex-wrap items-center gap-3">
+                      <button
+                        onClick={() => void handleReleaseFunds()}
+                        disabled={releasePhase !== "idle"}
+                        className="inline-flex items-center gap-2 w-full sm:w-auto justify-center btn-primary !py-3 !px-6 !rounded-xl font-black uppercase tracking-widest shadow-lg shadow-brand-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {releasePhase === "building" ? (
+                          <>
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Preparing...
+                          </>
+                        ) : (
+                          <>
+                            <ArrowUpRight className="h-4 w-4" />
+                            Release Funds
+                          </>
+                        )}
+                      </button>
+                      <button
+                        onClick={() => setShowShareModal(true)}
+                        className="inline-flex items-center gap-2 w-full sm:w-auto justify-center btn-secondary !py-3 !px-6 !rounded-xl font-black uppercase tracking-widest"
+                      >
+                        <Share2 className="h-4 w-4" />
+                        Share with Roommates
+                      </button>
+                    </div>
                   </div>
                 )}
               </div>
@@ -382,6 +407,15 @@ export default function EscrowDashboardClient({ contractId }: Props) {
                       </>
                     )}
                   </button>
+                </div>
+              )}
+
+              {showDisputeFlag && publicKey && (
+                <div className="animate-in fade-in slide-in-from-bottom-4 duration-700">
+                  <DisputeFlag
+                    contractId={contractId}
+                    roommateAddress={publicKey}
+                  />
                 </div>
               )}
 

--- a/app/escrows/page.tsx
+++ b/app/escrows/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ExternalLink, FileText, PlusCircle } from "lucide-react";
+import EscrowLabel from "@/components/escrow/EscrowLabel";
+
+const REGISTRY_KEY = "escrow_registry";
+
+function loadRegistry(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return JSON.parse(localStorage.getItem(REGISTRY_KEY) ?? "[]") as string[];
+  } catch {
+    return [];
+  }
+}
+
+export default function EscrowsPage() {
+  const [contractIds, setContractIds] = useState<string[]>([]);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setContractIds(loadRegistry());
+    setMounted(true);
+  }, []);
+
+  return (
+    <main
+      id="main-content"
+      aria-label="Escrow Registry"
+      className="min-h-screen pt-28 pb-20 relative overflow-hidden bg-[#0a0a0f]"
+    >
+      <div className="mesh-gradient opacity-40 mix-blend-screen pointer-events-none fixed inset-0" />
+      <div className="absolute top-0 left-1/4 w-[500px] h-[500px] bg-brand-500/10 blur-[150px] rounded-full pointer-events-none" />
+      <div className="absolute bottom-0 right-1/4 w-[500px] h-[500px] bg-accent-500/5 blur-[150px] rounded-full pointer-events-none" />
+
+      <div className="container relative z-10 mx-auto px-6 max-w-5xl">
+        <header className="mb-16 flex flex-col lg:flex-row lg:items-end justify-between gap-8">
+          <div className="space-y-5 animate-in fade-in slide-in-from-left-8 duration-700 ease-out">
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-2xl bg-brand-500/10 border border-brand-500/20 text-brand-300 text-[11px] font-black uppercase tracking-[0.2em]">
+              <FileText className="h-4 w-4" />
+              Property Registry
+            </div>
+            <div className="space-y-2">
+              <h1 className="text-5xl md:text-7xl font-black text-white tracking-tighter leading-[0.9] bg-gradient-to-br from-white via-white to-dark-700 bg-clip-text text-transparent">
+                Your <span className="text-brand-400">Escrows</span>
+              </h1>
+              <p className="text-dark-500 text-lg font-medium max-w-xl">
+                Manage and label your active rent escrow agreements.
+                Click any name to rename it.
+              </p>
+            </div>
+          </div>
+
+          <div className="animate-in fade-in slide-in-from-right-8 duration-700 ease-out">
+            <Link
+              href="/escrow/create"
+              className="btn-primary !py-3.5 !px-8 !rounded-2xl font-black uppercase tracking-widest flex items-center gap-2"
+            >
+              <PlusCircle className="h-4 w-4" />
+              New Escrow
+            </Link>
+          </div>
+        </header>
+
+        <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 ease-out delay-150">
+          {!mounted ? (
+            <div className="space-y-4">
+              {[...Array(3)].map((_, i) => (
+                <div
+                  key={i}
+                  className="glass-card p-6 flex items-center justify-between gap-6 animate-pulse"
+                >
+                  <div className="space-y-2">
+                    <div className="h-4 w-40 bg-white/5 rounded" />
+                    <div className="h-3 w-64 bg-white/5 rounded" />
+                  </div>
+                  <div className="h-8 w-24 bg-white/5 rounded-xl" />
+                </div>
+              ))}
+            </div>
+          ) : contractIds.length === 0 ? (
+            <div className="flex flex-col items-center text-center space-y-6 py-20">
+              <div className="p-6 rounded-2xl bg-white/5 border border-white/10">
+                <FileText className="h-12 w-12 text-dark-600" />
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-2xl font-black text-white">No Escrows Yet</h2>
+                <p className="text-dark-400 text-base max-w-sm">
+                  Escrows you create will appear here with their labels and status.
+                </p>
+              </div>
+              <Link
+                href="/escrow/create"
+                className="btn-primary !py-3 !px-8 !rounded-xl font-black uppercase tracking-widest flex items-center gap-2"
+              >
+                <PlusCircle className="h-4 w-4" />
+                Create Escrow
+              </Link>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {contractIds.map((contractId) => (
+                <div
+                  key={contractId}
+                  className="glass-card p-5 flex flex-col sm:flex-row sm:items-center justify-between gap-4 hover:border-white/10 transition-all"
+                >
+                  <div className="space-y-1.5">
+                    <EscrowLabel contractId={contractId} />
+                    <p className="text-dark-600 text-xs font-mono pl-0.5">
+                      {contractId}
+                    </p>
+                  </div>
+                  <Link
+                    href={`/escrow/${contractId}`}
+                    className="btn-secondary !py-2 !px-5 !rounded-xl !text-xs font-black uppercase tracking-widest flex items-center gap-2 shrink-0"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    Open
+                  </Link>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/escrow/CreateEscrowForm.tsx
+++ b/components/escrow/CreateEscrowForm.tsx
@@ -29,6 +29,8 @@ import {
   type EscrowFormDraft,
   type RoommateInputValue,
 } from "./createEscrowForm.helpers";
+import { useEscrowTemplates } from "@/hooks/useEscrowTemplates";
+import { BookmarkPlus, ChevronDown, Trash2 } from "lucide-react";
 
 interface InitializeEscrowParams {
   totalRent: string;
@@ -166,6 +168,12 @@ export default function CreateEscrowForm({
   const [submission, setSubmission] = useState<SubmissionState | null>(null);
   const [feeEstimateXlm, setFeeEstimateXlm] = useState<string | null>(null);
   const [feeStatus, setFeeStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
+
+  const { templates, saveTemplate, deleteTemplate, applyTemplate } = useEscrowTemplates();
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [saveTemplateName, setSaveTemplateName] = useState("");
+  const [showSaveTemplate, setShowSaveTemplate] = useState(false);
+  const [templateSaved, setTemplateSaved] = useState(false);
 
   function clearFieldError(field: string) {
     setFieldErrors((prev) => {
@@ -390,11 +398,26 @@ export default function CreateEscrowForm({
       const result = await createEscrow();
       setSubmission(result);
 
+      // Register escrow ID for the escrows listing page
+      if (result.contractId) {
+        try {
+          const existing: string[] = JSON.parse(
+            localStorage.getItem("escrow_registry") ?? "[]"
+          ) as string[];
+          if (!existing.includes(result.contractId)) {
+            localStorage.setItem(
+              "escrow_registry",
+              JSON.stringify([result.contractId, ...existing])
+            );
+          }
+        } catch {}
+      }
+
       // Clear draft on successful submission
       clearDraft();
 
-      // Redirect to success page
-      router.push(`/escrow/success?id=${result.contractId || ""}`);
+      // Show save-as-template prompt before redirect
+      setShowSaveTemplate(true);
     } catch (error) {
       setErrors([
         error instanceof Error
@@ -405,11 +428,122 @@ export default function CreateEscrowForm({
     }
   }
 
+  function handleProceedAfterTemplate() {
+    router.push(`/escrow/success?id=${submission?.contractId ?? ""}`);
+  }
+
+  function handleSaveAndProceed() {
+    if (saveTemplateName.trim()) {
+      saveTemplate(saveTemplateName.trim(), draft);
+    }
+    setTemplateSaved(true);
+    setTimeout(() => {
+      router.push(`/escrow/success?id=${submission?.contractId ?? ""}`);
+    }, 600);
+  }
+
   return (
     <section className="max-w-3xl mx-auto rounded-3xl glass overflow-hidden transition-all duration-500">
       <StepIndicator steps={STEP_LABELS} currentStep={step} />
-      
+
       <div className="p-6 sm:p-8 pt-0">
+
+      {/* Save-as-template prompt shown after successful submission */}
+      {showSaveTemplate && (
+        <div className="mb-6 rounded-xl border border-brand-400/40 bg-brand-500/10 p-5 space-y-4 animate-fade-in">
+          <div className="flex items-center gap-2 text-brand-200 font-black text-sm uppercase tracking-widest">
+            <BookmarkPlus className="h-4 w-4" />
+            Save as Template
+          </div>
+          <p className="text-dark-400 text-sm">
+            Save this setup so you can reuse it next month without re-entering details.
+          </p>
+          {templateSaved ? (
+            <p className="text-accent-300 text-sm font-medium">Template saved.</p>
+          ) : (
+            <div className="flex flex-col sm:flex-row gap-3">
+              <input
+                type="text"
+                value={saveTemplateName}
+                onChange={(e) => setSaveTemplateName(e.target.value)}
+                placeholder="Template name (e.g. Apt 4B Monthly)"
+                className="flex-1 rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-dark-100 outline-none focus:border-brand-400 transition-colors"
+              />
+              <button
+                type="button"
+                onClick={handleSaveAndProceed}
+                className="btn-primary !px-5 !py-2.5 !text-sm font-black"
+              >
+                Save & Continue
+              </button>
+              <button
+                type="button"
+                onClick={handleProceedAfterTemplate}
+                className="btn-secondary !px-5 !py-2.5 !text-sm"
+              >
+                Skip
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Template selector — only on step 1, before any draft banner */}
+      {!showSaveTemplate && step === 1 && templates.length > 0 && (
+        <div className="mb-4">
+          <button
+            type="button"
+            onClick={() => setShowTemplates((v) => !v)}
+            className="flex items-center gap-2 text-sm text-brand-300 hover:text-brand-200 transition-colors font-medium"
+          >
+            <BookmarkPlus className="h-4 w-4" />
+            Use a saved template
+            <ChevronDown
+              className={`h-4 w-4 transition-transform ${showTemplates ? "rotate-180" : ""}`}
+            />
+          </button>
+          {showTemplates && (
+            <div className="mt-3 rounded-xl border border-white/10 bg-white/5 divide-y divide-white/5 animate-fade-in">
+              {templates.map((tpl) => (
+                <div
+                  key={tpl.id}
+                  className="flex items-center justify-between gap-4 px-4 py-3"
+                >
+                  <div className="space-y-0.5">
+                    <p className="text-sm font-medium text-dark-200">{tpl.name}</p>
+                    <p className="text-xs text-dark-500">
+                      {tpl.totalRent} {tpl.tokenAddress} · {tpl.roommates.length} roommate
+                      {tpl.roommates.length !== 1 ? "s" : ""} · +{tpl.deadlineOffsetDays}d deadline
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const applied = applyTemplate(tpl);
+                        setDraft((current) => ({ ...current, ...applied }));
+                        setShowTemplates(false);
+                      }}
+                      className="btn-secondary !px-3 !py-1.5 !text-xs"
+                    >
+                      Apply
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteTemplate(tpl.id)}
+                      aria-label="Delete template"
+                      className="p-1.5 rounded-lg text-dark-500 hover:text-red-400 hover:bg-red-500/10 transition-all"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       {hasDraft && (
         <div className="mb-6 flex flex-col sm:flex-row items-center justify-between gap-4 rounded-xl border border-brand-400/40 bg-brand-500/10 p-4 text-sm animate-fade-in">
           <p className="text-brand-100 font-medium">You have an unsaved draft. Resume?</p>

--- a/components/escrow/DisputeFlag.tsx
+++ b/components/escrow/DisputeFlag.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, Flag, Loader2 } from "lucide-react";
+
+interface DisputeFlagProps {
+  contractId: string;
+  roommateAddress: string;
+}
+
+const STORAGE_KEY = "escrow_disputes";
+
+function readDisputes(): Record<string, boolean> {
+  if (typeof window === "undefined") return {};
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<
+      string,
+      boolean
+    >;
+  } catch {
+    return {};
+  }
+}
+
+function persistDispute(contractId: string): void {
+  const disputes = readDisputes();
+  disputes[contractId] = true;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(disputes));
+  } catch {}
+}
+
+export default function DisputeFlag({
+  contractId,
+  roommateAddress,
+}: DisputeFlagProps) {
+  const [isFlagged, setIsFlagged] = useState(false);
+  const [isFlagging, setIsFlagging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setIsFlagged(Boolean(readDisputes()[contractId]));
+  }, [contractId]);
+
+  async function handleFlag() {
+    setIsFlagging(true);
+    setError(null);
+    try {
+      await fetch("/api/disputes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contractId, roommateAddress }),
+      });
+    } catch {
+      // fall through — persist locally regardless
+    } finally {
+      persistDispute(contractId);
+      setIsFlagged(true);
+      setIsFlagging(false);
+    }
+  }
+
+  if (isFlagged) {
+    return (
+      <div
+        role="status"
+        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/30 text-amber-300 text-sm font-black uppercase tracking-widest"
+      >
+        <Flag className="h-4 w-4" />
+        Dispute Pending
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card p-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-5 border border-red-500/20 bg-red-500/5">
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 text-red-300 font-black text-sm uppercase tracking-widest">
+          <AlertTriangle className="h-4 w-4" />
+          Funds Unreleased Past Deadline
+        </div>
+        <p className="text-dark-400 text-sm max-w-md">
+          The escrow is fully funded but the landlord has not released funds.
+          You can flag a dispute to escalate this.
+        </p>
+        {error && <p className="text-red-400 text-xs mt-1">{error}</p>}
+      </div>
+      <button
+        onClick={() => void handleFlag()}
+        disabled={isFlagging}
+        className="btn-secondary !border-red-500/30 hover:!border-red-400/60 !text-red-300 hover:!bg-red-500/10 !py-2.5 !px-6 !rounded-xl font-black uppercase tracking-widest flex items-center gap-2 shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isFlagging ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Filing...
+          </>
+        ) : (
+          <>
+            <Flag className="h-4 w-4" />
+            Flag Dispute
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/components/escrow/EscrowLabel.tsx
+++ b/components/escrow/EscrowLabel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Check, Pencil, Tag, X } from "lucide-react";
+import { useEscrowLabels } from "@/hooks/useEscrowLabels";
+
+interface EscrowLabelProps {
+  contractId: string;
+  fallback?: string;
+}
+
+export default function EscrowLabel({ contractId, fallback }: EscrowLabelProps) {
+  const { getLabel, setLabel, removeLabel } = useEscrowLabels();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const label = getLabel(contractId);
+  const shortId =
+    fallback ??
+    (contractId.length > 10
+      ? `${contractId.slice(0, 6)}...${contractId.slice(-4)}`
+      : contractId);
+
+  function startEditing() {
+    setDraft(label ?? "");
+    setEditing(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }
+
+  function handleSave() {
+    if (draft.trim()) {
+      setLabel(contractId, draft.trim());
+    } else {
+      removeLabel(contractId);
+    }
+    setEditing(false);
+  }
+
+  function handleCancel() {
+    setEditing(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") handleSave();
+    if (e.key === "Escape") handleCancel();
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleSave}
+          placeholder="Enter label..."
+          className="rounded-lg border border-brand-500/40 bg-white/5 px-3 py-1.5 text-sm text-dark-100 outline-none focus:border-brand-400 transition-colors w-44"
+        />
+        <button
+          onMouseDown={(e) => {
+            e.preventDefault();
+            handleSave();
+          }}
+          aria-label="Save label"
+          className="p-1 text-accent-400 hover:text-accent-300 transition-colors"
+        >
+          <Check className="h-4 w-4" />
+        </button>
+        <button
+          onMouseDown={(e) => {
+            e.preventDefault();
+            handleCancel();
+          }}
+          aria-label="Cancel edit"
+          className="p-1 text-dark-400 hover:text-dark-200 transition-colors"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={startEditing}
+      title="Click to edit label"
+      className="group flex items-center gap-2 transition-colors"
+    >
+      {label ? (
+        <>
+          <Tag className="h-3.5 w-3.5 text-brand-400 shrink-0" />
+          <span className="text-sm font-medium text-white">{label}</span>
+        </>
+      ) : (
+        <span className="text-xs font-mono text-dark-500">{shortId}</span>
+      )}
+      <Pencil className="h-3 w-3 text-dark-600 group-hover:text-brand-400 transition-colors opacity-0 group-hover:opacity-100 shrink-0" />
+    </button>
+  );
+}

--- a/components/escrow/ShareEscrowModal.tsx
+++ b/components/escrow/ShareEscrowModal.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { X, Share2, Check, Copy, Link2 } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface ShareEscrowModalProps {
+  contractId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ShareEscrowModal({
+  contractId,
+  isOpen,
+  onClose,
+}: ShareEscrowModalProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [copied, setCopied] = useState(false);
+  const [canShare, setCanShare] = useState(false);
+  const [qrReady, setQrReady] = useState(false);
+
+  const shareUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/escrow/${contractId}`
+      : `/escrow/${contractId}`;
+
+  useEffect(() => {
+    setCanShare(typeof navigator !== "undefined" && "share" in navigator);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen || !canvasRef.current) return;
+
+    setQrReady(false);
+    import("qrcode")
+      .then((QRCode) => {
+        if (!canvasRef.current) return;
+        return QRCode.toCanvas(canvasRef.current, shareUrl, {
+          width: 192,
+          margin: 1,
+          color: {
+            dark: "#ffffff",
+            light: "#00000000",
+          },
+        });
+      })
+      .then(() => setQrReady(true))
+      .catch(() => setQrReady(false));
+  }, [isOpen, shareUrl]);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function handleNativeShare() {
+    if (!navigator.share) return;
+    try {
+      await navigator.share({
+        title: "PayEasy Escrow",
+        text: "Join my escrow and pay your rent share.",
+        url: shareUrl,
+      });
+    } catch {
+      // user cancelled or share not supported
+    }
+  }
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    if (e.target === e.currentTarget) onClose();
+  }
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-[200] flex items-center justify-center p-4 bg-dark-950/80 backdrop-blur-sm"
+          onClick={handleBackdropClick}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.92, y: 16 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.92, y: 16 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            className="glass-card w-full max-w-sm p-8 space-y-6 relative"
+          >
+            <button
+              onClick={onClose}
+              aria-label="Close share modal"
+              className="absolute top-4 right-4 p-1.5 rounded-lg text-dark-400 hover:text-white hover:bg-white/10 transition-all"
+            >
+              <X className="h-4 w-4" />
+            </button>
+
+            <div className="space-y-1">
+              <div className="inline-flex items-center gap-2 text-dark-400 text-[10px] font-black uppercase tracking-widest">
+                <Share2 className="h-3.5 w-3.5 text-brand-400" />
+                Share with Roommates
+              </div>
+              <h2 className="text-xl font-black text-white">Payment Link</h2>
+              <p className="text-dark-400 text-sm leading-relaxed">
+                Scan the QR code or copy the link to share this escrow with your roommates.
+              </p>
+            </div>
+
+            <div className="flex justify-center">
+              <div className="p-4 rounded-2xl bg-white/5 border border-white/10 relative">
+                {!qrReady && (
+                  <div className="absolute inset-4 flex items-center justify-center">
+                    <div className="h-6 w-6 rounded-full border-2 border-brand-400 border-t-transparent animate-spin" />
+                  </div>
+                )}
+                <canvas
+                  ref={canvasRef}
+                  className={`rounded-lg transition-opacity duration-300 ${qrReady ? "opacity-100" : "opacity-0"}`}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2.5">
+              <Link2 className="h-4 w-4 text-dark-500 shrink-0" />
+              <span className="text-dark-300 text-xs font-mono truncate flex-1">
+                {shareUrl}
+              </span>
+              <button
+                onClick={() => void handleCopy()}
+                aria-label="Copy link"
+                className="shrink-0 p-1.5 rounded-lg text-dark-400 hover:text-brand-400 hover:bg-white/5 transition-all"
+              >
+                <AnimatePresence mode="wait" initial={false}>
+                  {copied ? (
+                    <motion.div
+                      key="check"
+                      initial={{ opacity: 0, scale: 0.5 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.5 }}
+                      transition={{ duration: 0.15 }}
+                    >
+                      <Check className="h-4 w-4 text-accent-400" />
+                    </motion.div>
+                  ) : (
+                    <motion.div
+                      key="copy"
+                      initial={{ opacity: 0, scale: 0.5 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.5 }}
+                      transition={{ duration: 0.15 }}
+                    >
+                      <Copy className="h-4 w-4" />
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </button>
+            </div>
+
+            {canShare && (
+              <button
+                onClick={() => void handleNativeShare()}
+                className="btn-primary w-full !py-3 !rounded-xl font-black uppercase tracking-widest flex items-center justify-center gap-2"
+              >
+                <Share2 className="h-4 w-4" />
+                Share
+              </button>
+            )}
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/hooks/useEscrowLabels.ts
+++ b/hooks/useEscrowLabels.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+
+const STORAGE_KEY = "escrow_labels";
+
+function loadLabels(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<
+      string,
+      string
+    >;
+  } catch {
+    return {};
+  }
+}
+
+function persistLabels(labels: Record<string, string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(labels));
+  } catch {}
+}
+
+export function useEscrowLabels() {
+  const [labels, setLabels] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setLabels(loadLabels());
+  }, []);
+
+  const setLabel = useCallback((contractId: string, label: string) => {
+    setLabels((prev) => {
+      const next = { ...prev, [contractId]: label.trim() };
+      persistLabels(next);
+      return next;
+    });
+  }, []);
+
+  const removeLabel = useCallback((contractId: string) => {
+    setLabels((prev) => {
+      const next = { ...prev };
+      delete next[contractId];
+      persistLabels(next);
+      return next;
+    });
+  }, []);
+
+  const getLabel = useCallback(
+    (contractId: string): string | undefined => labels[contractId],
+    [labels]
+  );
+
+  return { labels, setLabel, removeLabel, getLabel };
+}

--- a/hooks/useEscrowTemplates.ts
+++ b/hooks/useEscrowTemplates.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import type {
+  EscrowFormDraft,
+  RoommateInputValue,
+} from "@/components/escrow/createEscrowForm.helpers";
+
+export interface EscrowTemplate {
+  id: string;
+  name: string;
+  totalRent: string;
+  tokenAddress: string;
+  deadlineOffsetDays: number;
+  roommates: Array<{ address: string; shareAmount: string }>;
+  createdAt: number;
+}
+
+const STORAGE_KEY = "escrow_templates";
+
+function loadFromStorage(): EscrowTemplate[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as EscrowTemplate[];
+  } catch {
+    return [];
+  }
+}
+
+function saveToStorage(templates: EscrowTemplate[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+  } catch {}
+}
+
+export function useEscrowTemplates() {
+  const [templates, setTemplates] = useState<EscrowTemplate[]>([]);
+
+  useEffect(() => {
+    setTemplates(loadFromStorage());
+  }, []);
+
+  const saveTemplate = useCallback(
+    (name: string, draft: EscrowFormDraft): EscrowTemplate => {
+      const today = new Date();
+      const deadlineDate = draft.deadlineDate
+        ? new Date(draft.deadlineDate)
+        : today;
+      const offsetDays = Math.max(
+        1,
+        Math.round(
+          (deadlineDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+        )
+      );
+
+      const template: EscrowTemplate = {
+        id: `tpl_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        name: name.trim() || "Unnamed Template",
+        totalRent: draft.totalRent,
+        tokenAddress: draft.tokenAddress,
+        deadlineOffsetDays: offsetDays,
+        roommates: draft.roommates.map((r) => ({
+          address: r.address,
+          shareAmount: r.shareAmount,
+        })),
+        createdAt: Date.now(),
+      };
+
+      setTemplates((prev) => {
+        const next = [template, ...prev];
+        saveToStorage(next);
+        return next;
+      });
+
+      return template;
+    },
+    []
+  );
+
+  const deleteTemplate = useCallback((id: string) => {
+    setTemplates((prev) => {
+      const next = prev.filter((t) => t.id !== id);
+      saveToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const applyTemplate = useCallback(
+    (template: EscrowTemplate): Partial<EscrowFormDraft> => {
+      const deadline = new Date();
+      deadline.setDate(deadline.getDate() + template.deadlineOffsetDays);
+      const deadlineDate = deadline.toISOString().split("T")[0] ?? "";
+
+      const roommates: RoommateInputValue[] = template.roommates.map(
+        (r, i) => ({
+          id: `${Date.now()}-${i}`,
+          address: r.address,
+          shareAmount: r.shareAmount,
+        })
+      );
+
+      return {
+        totalRent: template.totalRent,
+        tokenAddress: template.tokenAddress,
+        deadlineDate,
+        roommates,
+      };
+    },
+    []
+  );
+
+  return { templates, saveTemplate, deleteTemplate, applyTemplate };
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.6.1",
     "canvas-confetti": "^1.9.4",
+    "qrcode": "^1.5.3",
     "clsx": "^2.1.0",
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.400.0",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@next/bundle-analyzer": "^14.2.0",
     "@types/canvas-confetti": "^1.9.0",
+    "@types/qrcode": "^1.5.5",
     "@types/node": "^20.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",


### PR DESCRIPTION
closes #726, closes #730, closes #731, closes #733

## Summary

- **Issue #726 — Share Link with QR Code:** Added `ShareEscrowModal` component with a client-side QR code (rendered to canvas via the `qrcode` package), a copy-to-clipboard link row, and native Web Share API support. A "Share with Roommates" button is injected into the landlord-only action area of `EscrowDashboardClient`.

- **Issue #730 — Escrow Templates:** Added `useEscrowTemplates` hook storing templates in localStorage. `CreateEscrowForm` gains a template picker on step 1 (with apply/delete per entry) and a "Save as Template" prompt immediately after successful escrow creation, before redirecting to the success page.

- **Issue #731 — Dispute Flag:** Added `DisputeFlag` component visible to roommates when the escrow is fully funded (`status === "funded"`) and the deadline has passed. Clicking "Flag Dispute" calls `POST /api/disputes` (new Next.js route handler) and persists a local flag in localStorage so the "Dispute Pending" badge survives page refreshes.

- **Issue #733 — Property Labels:** Added `useEscrowLabels` hook (localStorage-backed) and `EscrowLabel` component with inline editing (Enter to save, Escape to cancel, click-outside saves). Created `app/escrows/page.tsx` as a property registry listing all created escrow IDs with their labels. The create flow writes new contract IDs to a `escrow_registry` localStorage key so the page populates automatically.

## Test plan

- [ ] As landlord, open any escrow dashboard — "Share with Roommates" button appears; clicking it opens a modal with a QR code and a copy link button
- [ ] Create an escrow; after confirmation the "Save as Template" prompt appears with a name input; saved template appears in the picker on the next create
- [ ] As a roommate on a funded+past-deadline escrow, the "Flag Dispute" card is visible; clicking it shows "Dispute Pending" badge and persists across reload
- [ ] Visit `/escrows`; created escrow IDs appear as cards; clicking any label opens an inline input; custom label persists and replaces the raw contract ID
