### PR TITLE
feat(escrow,pwa): multi-sig visualization, deadline extension, refund preview, offline support

### DIFF
--- a/__tests__/extendDeadline.test.ts
+++ b/__tests__/extendDeadline.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DeadlineNotLaterError,
+  extendDeadline,
+} from "../lib/stellar/actions/extendDeadline";
+
+describe("extendDeadline (validation)", () => {
+  it("rejects a non-finite or zero new deadline before touching the wallet", async () => {
+    await expect(
+      extendDeadline({
+        contractId: "CONTRACT",
+        landlordAddress: "GLANDLORD",
+        newDeadlineEpoch: 0,
+        currentDeadlineEpoch: 1_700_000_000,
+      })
+    ).rejects.toThrow(/positive Unix timestamp/i);
+
+    await expect(
+      extendDeadline({
+        contractId: "CONTRACT",
+        landlordAddress: "GLANDLORD",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        newDeadlineEpoch: Number.NaN as any,
+        currentDeadlineEpoch: 1_700_000_000,
+      })
+    ).rejects.toThrow(/positive Unix timestamp/i);
+  });
+
+  it("throws DeadlineNotLaterError when new deadline is not after the current one", async () => {
+    const currentDeadlineEpoch = 1_700_000_000;
+    const stubFreighter = {
+      getAddress: async () => ({ address: "GLANDLORD" }),
+      signTransaction: async () => ({ signedTxXdr: "x" }),
+    };
+
+    await expect(
+      extendDeadline(
+        {
+          contractId: "CONTRACT",
+          landlordAddress: "GLANDLORD",
+          newDeadlineEpoch: currentDeadlineEpoch, // not strictly later
+          currentDeadlineEpoch,
+        },
+        { freighter: stubFreighter }
+      )
+    ).rejects.toBeInstanceOf(DeadlineNotLaterError);
+
+    await expect(
+      extendDeadline(
+        {
+          contractId: "CONTRACT",
+          landlordAddress: "GLANDLORD",
+          newDeadlineEpoch: currentDeadlineEpoch - 1,
+          currentDeadlineEpoch,
+        },
+        { freighter: stubFreighter }
+      )
+    ).rejects.toBeInstanceOf(DeadlineNotLaterError);
+  });
+
+  it("rejects when the connected wallet does not match the landlord", async () => {
+    const currentDeadlineEpoch = 1_700_000_000;
+    const stubFreighter = {
+      getAddress: async () => ({ address: "GSOMEONEELSE" }),
+      signTransaction: async () => ({ signedTxXdr: "x" }),
+    };
+
+    await expect(
+      extendDeadline(
+        {
+          contractId: "CONTRACT",
+          landlordAddress: "GLANDLORD",
+          newDeadlineEpoch: currentDeadlineEpoch + 86_400,
+          currentDeadlineEpoch,
+        },
+        { freighter: stubFreighter }
+      )
+    ).rejects.toThrow(/does not match expected landlord/i);
+  });
+});

--- a/__tests__/getReleaseApprovalsForSigners.test.ts
+++ b/__tests__/getReleaseApprovalsForSigners.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { getReleaseApprovalsForSigners } from "../lib/stellar/queries";
+
+describe("getReleaseApprovalsForSigners", () => {
+  it("returns an empty list when no approvals are passed", () => {
+    const result = getReleaseApprovalsForSigners(
+      ["GLANDLORD", "GROOMMATEA"],
+      []
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("includes only addresses that match the configured signer list", () => {
+    const result = getReleaseApprovalsForSigners(
+      ["GLANDLORD", "GROOMMATEA"],
+      ["GLANDLORD", "GSTRANGER"]
+    );
+
+    expect(result.map((entry) => entry.signerAddress)).toEqual(["GLANDLORD"]);
+  });
+
+  it("deduplicates repeated approvals from the same signer", () => {
+    const result = getReleaseApprovalsForSigners(
+      ["GLANDLORD"],
+      ["GLANDLORD", "GLANDLORD", "GLANDLORD"]
+    );
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("stamps every approval with the same canonical timestamp", () => {
+    const now = new Date("2026-01-15T12:00:00Z");
+    const result = getReleaseApprovalsForSigners(
+      ["GLANDLORD", "GROOMMATEA"],
+      ["GLANDLORD", "GROOMMATEA"],
+      now
+    );
+
+    expect(result).toHaveLength(2);
+    for (const entry of result) {
+      expect(entry.approvedAt.toISOString()).toBe(now.toISOString());
+    }
+  });
+});

--- a/app/escrow/[contractId]/EscrowDashboardClient.tsx
+++ b/app/escrow/[contractId]/EscrowDashboardClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
+import ApprovalStatus from "@/components/escrow/ApprovalStatus";
 import EscrowStatus from "@/components/escrow/EscrowStatus";
 import FundingProgress from "@/components/escrow/FundingProgress";
 import MultiSigApproval from "@/components/escrow/MultiSigApproval";
@@ -24,7 +25,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { getExplorerLink } from "@/lib/stellar/explorer";
-import { createLandlordMajorityConfig } from "@/lib/stellar/multisig";
+import { createLandlordMajorityConfig, type ApprovalState } from "@/lib/stellar/multisig";
 import RefreshIndicator from "@/components/escrow/RefreshIndicator";
 import { useStellar } from "@/context/StellarContext";
 import { claimRefund, stroopsToXlm } from "@/lib/stellar/actions/claimRefund";
@@ -58,6 +59,7 @@ export default function EscrowDashboardClient({ contractId }: Props) {
   const [releaseError, setReleaseError] = useState<string | null>(null);
   const [isClaimingRefund, setIsClaimingRefund] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
+  const [approvals, setApprovals] = useState<ApprovalState[]>([]);
 
   const isLandlord =
     isConnected &&
@@ -481,7 +483,17 @@ export default function EscrowDashboardClient({ contractId }: Props) {
                 </div>
               )}
 
-              <MultiSigApproval config={multiSigConfig!} mockMode />
+              <ApprovalStatus
+                config={multiSigConfig!}
+                approvals={approvals}
+              />
+
+              <MultiSigApproval
+                config={multiSigConfig!}
+                mockMode
+                initialApprovals={approvals}
+                onApprovalChange={setApprovals}
+              />
             </div>
           )}
         </div>

--- a/app/escrow/[contractId]/EscrowDashboardClient.tsx
+++ b/app/escrow/[contractId]/EscrowDashboardClient.tsx
@@ -6,6 +6,7 @@ import EscrowStatus from "@/components/escrow/EscrowStatus";
 import ExtendDeadlineModal from "@/components/escrow/ExtendDeadlineModal";
 import FundingProgress from "@/components/escrow/FundingProgress";
 import MultiSigApproval from "@/components/escrow/MultiSigApproval";
+import RefundPreview from "@/components/escrow/RefundPreview";
 import RoommateTable from "@/components/escrow/RoommateTable";
 import ContributeForm from "@/components/escrow/ContributeForm";
 import MyPaymentHistory from "@/components/escrow/MyPaymentHistory";
@@ -490,33 +491,38 @@ export default function EscrowDashboardClient({ contractId }: Props) {
               )}
 
               {/* Claim Refund — visible only when eligible */}
-              {showClaimRefundButton && (
-                <div className="glass-card p-8 flex flex-col sm:flex-row items-center justify-between gap-6 border border-amber-500/20 bg-amber-500/5">
-                  <div className="space-y-1 text-center sm:text-left">
-                    <h3 className="text-white font-black text-lg uppercase tracking-widest">
-                      Refund Available
-                    </h3>
-                    <p className="text-dark-400 text-sm">
-                      The funding deadline has passed and the escrow was not fully funded. You can reclaim your deposit.
-                    </p>
+              {showClaimRefundButton && currentRoommate && (
+                <div className="space-y-4">
+                  <RefundPreview
+                    refundableStroops={currentRoommate.paidAmount}
+                  />
+                  <div className="glass-card p-8 flex flex-col sm:flex-row items-center justify-between gap-6 border border-amber-500/20 bg-amber-500/5">
+                    <div className="space-y-1 text-center sm:text-left">
+                      <h3 className="text-white font-black text-lg uppercase tracking-widest">
+                        Refund Available
+                      </h3>
+                      <p className="text-dark-400 text-sm">
+                        The funding deadline has passed and the escrow was not fully funded. You can reclaim your deposit.
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => void handleClaimRefund()}
+                      disabled={isClaimingRefund}
+                      className="btn-primary !w-full sm:!w-auto !justify-center !py-3 !px-8 !rounded-xl font-black uppercase tracking-widest flex items-center gap-2 shrink-0 disabled:opacity-50"
+                    >
+                      {isClaimingRefund ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Claiming...
+                        </>
+                      ) : (
+                        <>
+                          <RotateCcw className="h-4 w-4" />
+                          Claim Refund
+                        </>
+                      )}
+                    </button>
                   </div>
-                  <button
-                    onClick={() => void handleClaimRefund()}
-                    disabled={isClaimingRefund}
-                    className="btn-primary !w-full sm:!w-auto !justify-center !py-3 !px-8 !rounded-xl font-black uppercase tracking-widest flex items-center gap-2 shrink-0 disabled:opacity-50"
-                  >
-                    {isClaimingRefund ? (
-                      <>
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        Claiming...
-                      </>
-                    ) : (
-                      <>
-                        <RotateCcw className="h-4 w-4" />
-                        Claim Refund
-                      </>
-                    )}
-                  </button>
                 </div>
               )}
 

--- a/app/escrow/[contractId]/EscrowDashboardClient.tsx
+++ b/app/escrow/[contractId]/EscrowDashboardClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo } from "react";
 import ApprovalStatus from "@/components/escrow/ApprovalStatus";
 import EscrowStatus from "@/components/escrow/EscrowStatus";
+import ExtendDeadlineModal from "@/components/escrow/ExtendDeadlineModal";
 import FundingProgress from "@/components/escrow/FundingProgress";
 import MultiSigApproval from "@/components/escrow/MultiSigApproval";
 import RoommateTable from "@/components/escrow/RoommateTable";
@@ -16,6 +17,7 @@ import {
   ExternalLink,
   ShieldCheck,
   Activity,
+  Calendar,
   Globe,
   AlertCircle,
   Loader2,
@@ -59,6 +61,8 @@ export default function EscrowDashboardClient({ contractId }: Props) {
   const [releaseError, setReleaseError] = useState<string | null>(null);
   const [isClaimingRefund, setIsClaimingRefund] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
+  const [showExtendDeadlineModal, setShowExtendDeadlineModal] = useState(false);
+  const [extendBanner, setExtendBanner] = useState<string | null>(null);
   const [approvals, setApprovals] = useState<ApprovalState[]>([]);
 
   const isLandlord =
@@ -193,6 +197,21 @@ export default function EscrowDashboardClient({ contractId }: Props) {
         onClose={() => setShowShareModal(false)}
       />
 
+      {contractState && (
+        <ExtendDeadlineModal
+          contractId={contractId}
+          landlordAddress={contractState.landlord}
+          currentDeadlineEpoch={contractState.deadlineEpoch}
+          isOpen={showExtendDeadlineModal}
+          onClose={() => setShowExtendDeadlineModal(false)}
+          onExtended={(newEpoch) => {
+            const formatted = new Date(newEpoch * 1000).toLocaleString();
+            setExtendBanner(`Deadline extended to ${formatted}.`);
+            void refresh();
+          }}
+        />
+      )}
+
       {/* TransactionReview modal overlay */}
       {(releasePhase === "review" || releasePhase === "submitting") && preparedXdr && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-dark-950/80 backdrop-blur-sm animate-in fade-in duration-200">
@@ -323,6 +342,25 @@ export default function EscrowDashboardClient({ contractId }: Props) {
           </div>
         )}
 
+        {extendBanner && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mb-6 flex items-start gap-3 rounded-xl border border-brand-500/30 bg-brand-500/10 p-4 text-sm font-medium text-brand-100"
+          >
+            <Calendar className="h-4 w-4 mt-0.5 shrink-0 text-brand-300" />
+            <div className="flex-1">{extendBanner}</div>
+            <button
+              type="button"
+              onClick={() => setExtendBanner(null)}
+              className="text-xs font-bold uppercase tracking-widest text-brand-200 hover:text-white"
+              aria-label="Dismiss deadline extension notice"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+
         {/* Dashboard Grid — skeleton or real content */}
         <div className="space-y-12">
           {isLoading ? (
@@ -389,6 +427,14 @@ export default function EscrowDashboardClient({ contractId }: Props) {
                       >
                         <Share2 className="h-4 w-4" />
                         Share with Roommates
+                      </button>
+                      <button
+                        onClick={() => setShowExtendDeadlineModal(true)}
+                        disabled={releasePhase !== "idle"}
+                        className="inline-flex items-center gap-2 w-full sm:w-auto justify-center btn-secondary !py-3 !px-6 !rounded-xl font-black uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        <Calendar className="h-4 w-4" />
+                        Request Extension
                       </button>
                     </div>
                   </div>

--- a/components/escrow/ApprovalStatus.test.tsx
+++ b/components/escrow/ApprovalStatus.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import ApprovalStatus from "./ApprovalStatus";
+import {
+  createLandlordMajorityConfig,
+  mockApproval,
+} from "../../lib/stellar/multisig";
+
+function makeConfig() {
+  return createLandlordMajorityConfig({
+    escrowAccountId: "GESCROW",
+    landlordAddress: "GLANDLORD",
+    roommateAddresses: ["GROOMMATEA", "GROOMMATEB", "GROOMMATEC"],
+    networkPassphrase: "Test SDF Network ; September 2015",
+  });
+}
+
+describe("ApprovalStatus", () => {
+  it("renders X of Y approval headline with zero approvals", () => {
+    const config = makeConfig();
+
+    render(<ApprovalStatus config={config} approvals={[]} />);
+
+    // Landlord + 3 roommates = 4 signers total, 0 approved.
+    expect(
+      screen.getByText(/0 of 4 approvals received/i)
+    ).toBeTruthy();
+    expect(screen.getAllByText(/pending/i).length).toBeGreaterThan(0);
+  });
+
+  it("reflects partial approvals (acceptance criteria: 2 of N visualization)", () => {
+    const config = makeConfig();
+    const approvals = [
+      mockApproval("GLANDLORD"),
+      mockApproval("GROOMMATEA"),
+    ];
+
+    render(<ApprovalStatus config={config} approvals={approvals} />);
+
+    expect(
+      screen.getByText(/2 of 4 approvals received/i)
+    ).toBeTruthy();
+  });
+
+  it("ignores approvals for unknown signers in the count", () => {
+    const config = makeConfig();
+    const approvals = [
+      mockApproval("GSTRANGER"),
+      mockApproval("GLANDLORD"),
+    ];
+
+    render(<ApprovalStatus config={config} approvals={approvals} />);
+
+    // Only the landlord matches the configured signer list.
+    expect(
+      screen.getByText(/1 of 4 approvals received/i)
+    ).toBeTruthy();
+  });
+
+  it("announces threshold-satisfied state when release is ready", () => {
+    const config = makeConfig();
+    const approvals = [
+      mockApproval("GLANDLORD"),
+      mockApproval("GROOMMATEA"),
+      mockApproval("GROOMMATEB"),
+    ];
+
+    render(<ApprovalStatus config={config} approvals={approvals} />);
+
+    expect(
+      screen.getByText(/threshold satisfied/i)
+    ).toBeTruthy();
+  });
+});

--- a/components/escrow/ApprovalStatus.tsx
+++ b/components/escrow/ApprovalStatus.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { Check, ShieldCheck, UserCheck, Users } from "lucide-react";
+
+import {
+  type ApprovalState,
+  type MultiSigConfig,
+  type Signer,
+  accumulatedWeight,
+  approvedRoommateCount,
+  hasLandlordApproval,
+  isReleaseApproved,
+  requiredRoommateApprovals,
+} from "@/lib/stellar/multisig";
+
+interface ApprovalStatusProps {
+  config: MultiSigConfig;
+  approvals?: ApprovalState[];
+}
+
+function formatAddress(address: string): string {
+  if (address.length <= 16) return address;
+  return `${address.slice(0, 8)}...${address.slice(-6)}`;
+}
+
+/**
+ * Read-only visualization of multi-sig release approvals.
+ *
+ * Surfaces three pieces of information for the escrow dashboard:
+ *   - "X of Y approvals received" headline
+ *   - Per-signer approved / pending indicators with role labels
+ *   - Weighted progress bar against the configured threshold
+ *
+ * The interactive signing flow lives in `MultiSigApproval.tsx`. This component
+ * is intentionally pure — it never calls a wallet or mutates state — so it can
+ * safely render alongside the contract overview without competing for signer
+ * focus.
+ */
+export default function ApprovalStatus({
+  config,
+  approvals = [],
+}: ApprovalStatusProps) {
+  const approvedAddresses = new Set(approvals.map((a) => a.signerAddress));
+  const totalSigners = config.signers.length;
+  const approvedCount = config.signers.filter((s) =>
+    approvedAddresses.has(s.address)
+  ).length;
+
+  const landlordApproved = hasLandlordApproval(approvals, config);
+  const roommateApprovals = approvedRoommateCount(approvals, config);
+  const roommateRequired = requiredRoommateApprovals(config);
+  const weight = accumulatedWeight(approvals, config);
+  const releaseReady = isReleaseApproved(approvals, config);
+  const progressPercent = Math.min((weight / config.threshold) * 100, 100);
+
+  return (
+    <section
+      className="glass-card p-6 sm:p-8"
+      aria-label="Multi-signature approval status"
+    >
+      <header className="mb-6 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-brand-200">
+            <ShieldCheck className="h-3.5 w-3.5" />
+            Release Approvals
+          </div>
+          <div>
+            <h2 className="text-2xl font-black text-white">
+              {approvedCount} of {totalSigners} approvals received
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm font-medium leading-relaxed text-dark-400">
+              {releaseReady
+                ? "Approval threshold satisfied. Funds can be released."
+                : `Landlord plus ${roommateRequired} roommate${
+                    roommateRequired === 1 ? "" : "s"
+                  } required before release.`}
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <p className="text-[10px] font-black uppercase tracking-widest text-dark-500">
+            Signature Weight
+          </p>
+          <p className="mt-1 text-2xl font-black text-white">
+            {weight}
+            <span className="text-sm text-dark-500"> / {config.threshold}</span>
+          </p>
+          <div
+            className="mt-3 h-2 w-48 max-w-full overflow-hidden rounded-full bg-white/10"
+            role="progressbar"
+            aria-valuenow={weight}
+            aria-valuemin={0}
+            aria-valuemax={config.threshold}
+            aria-label="Approval threshold progress"
+          >
+            <div
+              className={`h-full rounded-full transition-all ${
+                releaseReady ? "bg-accent-400" : "bg-brand-400"
+              }`}
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+        </div>
+      </header>
+
+      <div className="mb-6 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <p className="text-[10px] font-black uppercase tracking-widest text-dark-500">
+            Landlord
+          </p>
+          <p className="mt-2 flex items-center gap-2 text-sm font-bold text-dark-100">
+            {landlordApproved ? (
+              <Check className="h-4 w-4 text-accent-300" aria-hidden="true" />
+            ) : (
+              <UserCheck className="h-4 w-4 text-dark-500" aria-hidden="true" />
+            )}
+            {landlordApproved ? "Approved" : "Pending"}
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <p className="text-[10px] font-black uppercase tracking-widest text-dark-500">
+            Roommates
+          </p>
+          <p className="mt-2 flex items-center gap-2 text-sm font-bold text-dark-100">
+            <Users className="h-4 w-4 text-brand-300" aria-hidden="true" />
+            {roommateApprovals} / {roommateRequired}
+          </p>
+        </div>
+      </div>
+
+      <ul className="space-y-3" aria-label="Signer approval list">
+        {config.signers.map((signer) => (
+          <SignerRow
+            key={signer.address}
+            signer={signer}
+            approved={approvedAddresses.has(signer.address)}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+interface SignerRowProps {
+  signer: Signer;
+  approved: boolean;
+}
+
+function SignerRow({ signer, approved }: SignerRowProps) {
+  const isLandlord = signer.role === "landlord";
+
+  return (
+    <li
+      className={`rounded-2xl border px-4 py-4 transition-colors ${
+        approved
+          ? "border-accent-400/40 bg-accent-500/10"
+          : "border-white/10 bg-white/[0.03]"
+      }`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <div
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border ${
+              isLandlord
+                ? "border-brand-400/40 bg-brand-500/15 text-brand-200"
+                : "border-accent-400/30 bg-accent-500/10 text-accent-200"
+            }`}
+            aria-hidden="true"
+          >
+            {isLandlord ? (
+              <ShieldCheck className="h-5 w-5" />
+            ) : (
+              <Users className="h-5 w-5" />
+            )}
+          </div>
+
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-sm font-bold capitalize text-dark-100">
+                {signer.role}
+              </p>
+              <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-dark-400">
+                Weight {signer.weight}
+              </span>
+            </div>
+            <p className="mt-1 truncate font-mono text-xs text-dark-500">
+              {formatAddress(signer.address)}
+            </p>
+          </div>
+        </div>
+
+        <span
+          className={`inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-xs font-bold ${
+            approved
+              ? "border-accent-400/30 bg-accent-500/10 text-accent-200"
+              : "border-white/10 bg-white/5 text-dark-400"
+          }`}
+        >
+          {approved ? (
+            <>
+              <Check className="h-4 w-4" aria-hidden="true" />
+              Approved
+            </>
+          ) : (
+            "Pending"
+          )}
+        </span>
+      </div>
+    </li>
+  );
+}

--- a/components/escrow/ExtendDeadlineModal.tsx
+++ b/components/escrow/ExtendDeadlineModal.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, Calendar, Loader2, X } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+
+import {
+  DeadlineNotLaterError,
+  extendDeadline,
+} from "@/lib/stellar/actions/extendDeadline";
+
+interface ExtendDeadlineModalProps {
+  contractId: string;
+  landlordAddress: string;
+  /** Current on-chain deadline in Unix seconds. */
+  currentDeadlineEpoch: number;
+  isOpen: boolean;
+  onClose: () => void;
+  /**
+   * Fired when the contract confirms the new deadline. Receives the new
+   * deadline epoch in Unix seconds so the caller can show an in-app banner
+   * (see acceptance criteria: notify all roommates).
+   */
+  onExtended: (newDeadlineEpoch: number) => void;
+}
+
+const MIN_BUFFER_SECONDS = 60 * 60; // require at least 1 hour beyond current
+
+function epochToInputValue(epoch: number): string {
+  // Returns a "YYYY-MM-DDTHH:mm" value suitable for <input type="datetime-local">.
+  // We render in the user's local timezone to match the picker semantics.
+  const date = new Date(epoch * 1000);
+  const pad = (n: number): string => n.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function inputValueToEpoch(value: string): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return null;
+  return Math.floor(parsed / 1000);
+}
+
+/**
+ * Landlord-only modal for requesting a deadline extension on an active escrow.
+ *
+ * Acceptance criteria:
+ *   - Date picker; new deadline must be strictly after the current one
+ *   - On success, the new deadline reflects immediately on the dashboard
+ *     (parent refreshes contract state via `onExtended`)
+ *   - Errors from the wallet / contract are surfaced inline rather than
+ *     thrown to the caller
+ */
+export default function ExtendDeadlineModal({
+  contractId,
+  landlordAddress,
+  currentDeadlineEpoch,
+  isOpen,
+  onClose,
+  onExtended,
+}: ExtendDeadlineModalProps) {
+  const defaultProposedEpoch = currentDeadlineEpoch + MIN_BUFFER_SECONDS * 24; // +1 day
+  const [deadlineInput, setDeadlineInput] = useState(() =>
+    epochToInputValue(defaultProposedEpoch)
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the form whenever the modal reopens so stale values don't linger.
+  useEffect(() => {
+    if (isOpen) {
+      setDeadlineInput(epochToInputValue(defaultProposedEpoch));
+      setError(null);
+      setIsSubmitting(false);
+    }
+  }, [isOpen, defaultProposedEpoch]);
+
+  const minPickerValue = useMemo(
+    () => epochToInputValue(currentDeadlineEpoch + MIN_BUFFER_SECONDS),
+    [currentDeadlineEpoch]
+  );
+
+  const currentDeadlineLabel = useMemo(
+    () => new Date(currentDeadlineEpoch * 1000).toLocaleString(),
+    [currentDeadlineEpoch]
+  );
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    const newEpoch = inputValueToEpoch(deadlineInput);
+    if (newEpoch === null) {
+      setError("Please choose a valid date and time.");
+      return;
+    }
+
+    if (newEpoch <= currentDeadlineEpoch) {
+      setError("New deadline must be after the current deadline.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const result = await extendDeadline({
+        contractId,
+        landlordAddress,
+        newDeadlineEpoch: newEpoch,
+        currentDeadlineEpoch,
+      });
+      onExtended(result.newDeadlineEpoch);
+      onClose();
+    } catch (err) {
+      if (err instanceof DeadlineNotLaterError) {
+        setError("New deadline must be after the current deadline.");
+      } else if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Failed to extend deadline.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleBackdropClick(event: React.MouseEvent) {
+    if (event.target === event.currentTarget && !isSubmitting) {
+      onClose();
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-[200] flex items-center justify-center p-4 bg-dark-950/80 backdrop-blur-sm"
+          onClick={handleBackdropClick}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Request deadline extension"
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.92, y: 16 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.92, y: 16 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            className="glass-card w-full max-w-md p-8 space-y-6 relative"
+          >
+            <button
+              onClick={onClose}
+              disabled={isSubmitting}
+              aria-label="Close extend deadline modal"
+              className="absolute top-4 right-4 p-1.5 rounded-lg text-dark-400 hover:text-white hover:bg-white/10 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <X className="h-4 w-4" />
+            </button>
+
+            <div className="space-y-1">
+              <div className="inline-flex items-center gap-2 text-dark-400 text-[10px] font-black uppercase tracking-widest">
+                <Calendar className="h-3.5 w-3.5 text-brand-400" />
+                Landlord Action
+              </div>
+              <h2 className="text-xl font-black text-white">
+                Extend Funding Deadline
+              </h2>
+              <p className="text-dark-400 text-sm leading-relaxed">
+                Give roommates more time to contribute. The new deadline must be
+                after{" "}
+                <span className="text-dark-200 font-bold">
+                  {currentDeadlineLabel}
+                </span>
+                . All roommates will be notified in-app once confirmed on-chain.
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <label className="block space-y-2">
+                <span className="block text-[10px] font-black uppercase tracking-widest text-dark-500">
+                  New Deadline
+                </span>
+                <input
+                  type="datetime-local"
+                  value={deadlineInput}
+                  min={minPickerValue}
+                  required
+                  disabled={isSubmitting}
+                  onChange={(e) => setDeadlineInput(e.target.value)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-medium text-white placeholder-dark-500 focus:border-brand-400/60 focus:outline-none focus:ring-2 focus:ring-brand-400/20 disabled:opacity-50"
+                  aria-describedby="extend-deadline-helper"
+                />
+                <span
+                  id="extend-deadline-helper"
+                  className="block text-[11px] font-medium text-dark-500"
+                >
+                  Use your local timezone. We require at least one hour past the
+                  current deadline.
+                </span>
+              </label>
+
+              {error && (
+                <div
+                  role="alert"
+                  className="flex items-start gap-3 rounded-2xl border border-red-400/30 bg-red-500/10 p-3 text-sm font-medium text-red-200"
+                >
+                  <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                  <p>{error}</p>
+                </div>
+              )}
+
+              <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  disabled={isSubmitting}
+                  className="btn-secondary !py-3 !px-6 !rounded-xl font-black uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="btn-primary !py-3 !px-6 !rounded-xl font-black uppercase tracking-widest flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Extending…
+                    </>
+                  ) : (
+                    <>
+                      <Calendar className="h-4 w-4" />
+                      Request Extension
+                    </>
+                  )}
+                </button>
+              </div>
+            </form>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/escrow/RefundPreview.test.tsx
+++ b/components/escrow/RefundPreview.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import RefundPreview from "./RefundPreview";
+
+describe("RefundPreview", () => {
+  it("renders the refund amount in XLM from stroops", () => {
+    // 25 XLM in stroops.
+    render(<RefundPreview refundableStroops="250000000" />);
+
+    expect(screen.getByText(/25 XLM/)).toBeTruthy();
+    expect(screen.getByText(/your full contribution/i)).toBeTruthy();
+  });
+
+  it("preserves fractional XLM precision", () => {
+    // 1.2345 XLM in stroops.
+    render(<RefundPreview refundableStroops="12345000" />);
+
+    expect(screen.getByText(/1.2345 XLM/)).toBeTruthy();
+  });
+
+  it("clarifies that gas fees will be deducted on submit", () => {
+    render(<RefundPreview refundableStroops="100000000" />);
+
+    expect(
+      screen.getByText(/network fees \(paid in XLM\) will be deducted/i)
+    ).toBeTruthy();
+  });
+
+  it("falls back to 0 XLM rather than crashing on invalid input", () => {
+    render(<RefundPreview refundableStroops="not-a-number" />);
+
+    expect(screen.getByText(/0 XLM/)).toBeTruthy();
+  });
+
+  it("supports a custom label for partial refund scenarios", () => {
+    render(
+      <RefundPreview
+        refundableStroops="500000000"
+        label="50% of your contribution"
+      />
+    );
+
+    expect(screen.getByText(/50 XLM/)).toBeTruthy();
+    expect(screen.getByText(/50% of your contribution/i)).toBeTruthy();
+  });
+});

--- a/components/escrow/RefundPreview.tsx
+++ b/components/escrow/RefundPreview.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Coins, Fuel, Info } from "lucide-react";
+
+import { stroopsToXlm } from "@/lib/stellar/actions/claimRefund";
+
+interface RefundPreviewProps {
+  /**
+   * Roommate's refundable contribution, in stroops (1 XLM = 10,000,000 stroops).
+   * Pass the on-chain `paid_amount` so this preview matches what `claim_refund`
+   * will actually transfer.
+   */
+  refundableStroops: string;
+  /**
+   * Optional copy override — e.g. when the eligible amount differs from the
+   * roommate's full contribution (partial refund scenarios).
+   */
+  label?: string;
+}
+
+/**
+ * Renders the refund amount a roommate will receive before they commit to the
+ * Claim Refund action. Pure presentational component — never calls the
+ * network or wallet itself.
+ *
+ * Surfaces three things acceptance criteria require:
+ *   1. Exact refund amount in XLM with explicit unit
+ *   2. Clarification that this is the roommate's full contribution
+ *   3. Notice that Stellar network gas fees will be deducted on submit
+ */
+export default function RefundPreview({
+  refundableStroops,
+  label = "your full contribution",
+}: RefundPreviewProps) {
+  let amountXlm: string;
+  try {
+    amountXlm = stroopsToXlm(refundableStroops);
+  } catch {
+    // Defensive: stroopsToXlm uses BigInt(), which throws on non-numeric input.
+    // Show a fallback rather than crashing the dashboard.
+    amountXlm = "0";
+  }
+
+  // Strip trailing zeros for a cleaner display while keeping the precision
+  // identical to what the action returns on success.
+  const displayAmount = amountXlm.includes(".")
+    ? amountXlm.replace(/0+$/, "").replace(/\.$/, "")
+    : amountXlm;
+
+  return (
+    <section
+      className="glass-card border border-amber-500/20 bg-amber-500/5 p-6 sm:p-8"
+      aria-label="Refund preview"
+    >
+      <div className="flex flex-col gap-5">
+        <div className="flex items-start gap-3">
+          <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-3 text-amber-200">
+            <Coins className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-[10px] font-black uppercase tracking-widest text-amber-200/80">
+              Refund Preview
+            </p>
+            <p className="text-lg font-black text-white sm:text-xl">
+              You will receive back{" "}
+              <span className="text-amber-200">{displayAmount} XLM</span>
+              <span className="text-sm font-medium text-dark-300">
+                {" "}
+                ({label})
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm font-medium text-dark-300">
+          <Fuel
+            className="mt-0.5 h-4 w-4 shrink-0 text-dark-500"
+            aria-hidden="true"
+          />
+          <p>
+            Stellar network fees (paid in XLM) will be deducted from your wallet
+            when you submit the claim. The on-chain refund amount above is
+            transferred in full.
+          </p>
+        </div>
+
+        <p className="flex items-start gap-2 text-xs font-medium text-dark-500">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          Refunds are only available once the funding deadline has passed
+          without the escrow reaching its goal.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/app-shell.tsx
+++ b/components/ui/app-shell.tsx
@@ -8,6 +8,7 @@ import { SkipLink } from "@/components/ui/skip-link";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import OfflineBanner from "./offline-banner";
 import AccountChangedBanner from "./account-changed-banner";
+import ServiceWorkerManager from "./service-worker-manager";
 
 /** True when the device reports fewer than 4 logical CPU cores. */
 const isLowEnd =
@@ -59,6 +60,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <ErrorBoundary>
         <OfflineBanner />
         <AccountChangedBanner />
+        <ServiceWorkerManager />
         <div className="relative z-10">{children}</div>
       </ErrorBoundary>
     </ThemeProvider>

--- a/components/ui/service-worker-manager.tsx
+++ b/components/ui/service-worker-manager.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { RefreshCcw } from "lucide-react";
+
+/**
+ * Registers the PayEasy service worker on first paint and surfaces an
+ * "Update available" banner when a new worker takes over.
+ *
+ * The worker itself (`/sw.js`) is shared with the push-reminder flow, so this
+ * component is intentionally idempotent — calling `register("/sw.js")` again
+ * after the push prompt does the same is safe and returns the existing
+ * registration.
+ *
+ * Behavior:
+ *   - Skip entirely outside the browser, during dev, or when service workers
+ *     are unsupported.
+ *   - Listen for `controllerchange` and the worker's `payeasy:update-available`
+ *     message to decide when to show the banner.
+ *   - On "Refresh now", post `payeasy:skip-waiting` and reload so the new
+ *     assets are picked up immediately.
+ */
+export default function ServiceWorkerManager() {
+  const [updateReady, setUpdateReady] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator)) return;
+    if (process.env.NODE_ENV === "development") return;
+
+    let cancelled = false;
+    let registration: ServiceWorkerRegistration | null = null;
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data && event.data.type === "payeasy:update-available") {
+        setUpdateReady(true);
+      }
+    };
+
+    const handleControllerChange = () => {
+      if (isRefreshing) return;
+      // A new worker took over without us asking — surface the prompt.
+      setUpdateReady(true);
+    };
+
+    void (async () => {
+      try {
+        registration = await navigator.serviceWorker.register("/sw.js");
+        if (cancelled) return;
+
+        // If a worker is already waiting when we register, prompt immediately.
+        if (registration.waiting) {
+          setUpdateReady(true);
+        }
+
+        registration.addEventListener("updatefound", () => {
+          const installing = registration?.installing;
+          if (!installing) return;
+          installing.addEventListener("statechange", () => {
+            if (
+              installing.state === "installed" &&
+              navigator.serviceWorker.controller
+            ) {
+              setUpdateReady(true);
+            }
+          });
+        });
+      } catch {
+        // Registration failures (e.g. private mode) are not actionable for
+        // users; keep the failure silent and skip the offline fallback path.
+      }
+    })();
+
+    navigator.serviceWorker.addEventListener("message", handleMessage);
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      handleControllerChange
+    );
+
+    return () => {
+      cancelled = true;
+      navigator.serviceWorker.removeEventListener("message", handleMessage);
+      navigator.serviceWorker.removeEventListener(
+        "controllerchange",
+        handleControllerChange
+      );
+    };
+  }, [isRefreshing]);
+
+  async function handleRefresh() {
+    setIsRefreshing(true);
+    try {
+      const registration = await navigator.serviceWorker.getRegistration();
+      registration?.waiting?.postMessage({ type: "payeasy:skip-waiting" });
+    } catch {
+      // ignore — fall through to a hard reload regardless
+    }
+    window.location.reload();
+  }
+
+  if (!updateReady) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-6 left-1/2 z-[110] -translate-x-1/2 px-4"
+    >
+      <div className="glass flex items-center gap-3 rounded-2xl border border-brand-400/30 bg-brand-500/10 px-4 py-3 shadow-2xl backdrop-blur-xl">
+        <RefreshCcw
+          className="h-4 w-4 text-brand-300 shrink-0"
+          aria-hidden="true"
+        />
+        <span className="text-sm font-medium text-white">
+          Update available
+        </span>
+        <button
+          type="button"
+          onClick={() => void handleRefresh()}
+          disabled={isRefreshing}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-[11px] font-black uppercase tracking-widest text-white transition hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isRefreshing ? "Refreshing…" : "Refresh now"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setUpdateReady(false)}
+          className="text-[11px] font-bold uppercase tracking-widest text-dark-300 hover:text-white"
+          aria-label="Dismiss update notice"
+        >
+          Later
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/stellar/actions/extendDeadline.ts
+++ b/lib/stellar/actions/extendDeadline.ts
@@ -1,0 +1,415 @@
+/**
+ * Frontend action for extending the deadline of an existing escrow contract.
+ *
+ * Mirrors the structure of `claimRefund.ts` / `release.ts`:
+ *  1. Resolves the current on-chain deadline so we can guarantee the new one
+ *     is strictly later.
+ *  2. Confirms the connected Freighter wallet matches the landlord.
+ *  3. Builds, signs, submits, and confirms the Soroban transaction calling
+ *     `extend_deadline(landlord, new_deadline)` on the escrow contract.
+ *
+ * The contract method name is resolved against a small candidate list so a
+ * frontend deploy is not blocked by a rename on the contract side.
+ */
+
+import {
+  Account,
+  Address,
+  BASE_FEE,
+  Contract,
+  Networks,
+  TransactionBuilder,
+  rpc,
+  scValToNative,
+  xdr,
+  nativeToScVal,
+} from "@stellar/stellar-sdk";
+
+export const NETWORK_PASSPHRASE = Networks.TESTNET;
+export const RPC_URL = "https://soroban-testnet.stellar.org";
+const DEFAULT_TIMEOUT_SECONDS = 300;
+const MAX_CONFIRMATION_RETRIES = 20;
+const CONFIRMATION_DELAY_MS = 1500;
+const EXTEND_METHOD_CANDIDATES = [
+  "extend_deadline",
+  "update_deadline",
+  "set_deadline",
+] as const;
+
+export type ExtendMethodName = (typeof EXTEND_METHOD_CANDIDATES)[number];
+
+export interface ExtendDeadlineParams {
+  contractId: string;
+  landlordAddress: string;
+  /** New deadline in Unix seconds. Must be strictly after the current one. */
+  newDeadlineEpoch: number;
+  /**
+   * Optional trusted current deadline already fetched from the contract.
+   * When omitted, the action reads `get_deadline()` from the contract.
+   */
+  currentDeadlineEpoch?: number;
+}
+
+export interface ExtendDeadlineResult {
+  txHash: string;
+  previousDeadlineEpoch: number;
+  newDeadlineEpoch: number;
+  confirmedAt: Date;
+  method: ExtendMethodName;
+}
+
+export class DeadlineNotLaterError extends Error {
+  readonly currentDeadlineEpoch: number;
+  readonly requestedDeadlineEpoch: number;
+
+  constructor(currentDeadlineEpoch: number, requestedDeadlineEpoch: number) {
+    super(
+      `New deadline (${new Date(
+        requestedDeadlineEpoch * 1000
+      ).toISOString()}) must be after the current deadline (${new Date(
+        currentDeadlineEpoch * 1000
+      ).toISOString()}).`
+    );
+    this.name = "DeadlineNotLaterError";
+    this.currentDeadlineEpoch = currentDeadlineEpoch;
+    this.requestedDeadlineEpoch = requestedDeadlineEpoch;
+  }
+}
+
+export class FreighterNotAvailableError extends Error {
+  constructor() {
+    super("Freighter wallet extension not found. Please install it.");
+    this.name = "FreighterNotAvailableError";
+  }
+}
+
+export class ExtendMethodResolutionError extends Error {
+  constructor() {
+    super(
+      "Unable to resolve a supported deadline extension method on the escrow contract."
+    );
+    this.name = "ExtendMethodResolutionError";
+  }
+}
+
+export interface FreighterAddressResponse {
+  address: string;
+  error?: unknown;
+}
+
+export interface FreighterSignResponse {
+  signedTxXdr?: string;
+  txXdr?: string;
+  error?: unknown;
+}
+
+export interface FreighterClient {
+  getAddress: () => Promise<FreighterAddressResponse>;
+  signTransaction: (
+    transactionXdr: string,
+    options?: { networkPassphrase?: string; address?: string }
+  ) => Promise<FreighterSignResponse>;
+}
+
+export interface ExtendDeadlineDependencies {
+  server?: rpc.Server;
+  freighter?: FreighterClient;
+  networkPassphrase?: string;
+  rpcUrl?: string;
+  sleep?: (ms: number) => Promise<void>;
+  extendMethodCandidates?: readonly ExtendMethodName[];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function loadFreighterClient(): Promise<FreighterClient> {
+  if (
+    typeof window === "undefined" ||
+    !(window as Window & { freighter?: unknown }).freighter
+  ) {
+    throw new FreighterNotAvailableError();
+  }
+
+  const freighterModule = await import("@stellar/freighter-api");
+  const freighter =
+    "default" in freighterModule ? freighterModule.default : freighterModule;
+
+  return {
+    getAddress: freighter.getAddress,
+    signTransaction: freighter.signTransaction,
+  };
+}
+
+function getServer(deps: ExtendDeadlineDependencies): rpc.Server {
+  return deps.server ?? new rpc.Server(deps.rpcUrl ?? RPC_URL);
+}
+
+function getNetworkPassphrase(deps: ExtendDeadlineDependencies): string {
+  return deps.networkPassphrase ?? NETWORK_PASSPHRASE;
+}
+
+async function getSourceAccount(
+  server: rpc.Server,
+  address: string
+): Promise<Account> {
+  return server
+    .getAccount(address)
+    .catch(() => new Account(address, "0"));
+}
+
+function getSimulationReturnValue(
+  simulation: rpc.Api.SimulateTransactionResponse
+): unknown {
+  const simulationShape = simulation as {
+    result?: { retval?: unknown };
+    results?: Array<{ retval?: unknown }>;
+  };
+  const resultRetval = simulationShape.result?.retval;
+  const resultsRetval = simulationShape.results?.[0]?.retval;
+
+  return resultRetval ?? resultsRetval;
+}
+
+function parseEpoch(value: unknown): number {
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.length > 0) return Number.parseInt(value, 10);
+
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    for (const key of ["u64", "value"]) {
+      const nested = obj[key];
+      if (typeof nested === "bigint") return Number(nested);
+      if (typeof nested === "number" && Number.isFinite(nested)) return nested;
+      if (typeof nested === "string" && nested.length > 0) {
+        return Number.parseInt(nested, 10);
+      }
+    }
+  }
+
+  throw new Error("Unable to parse deadline from contract response.");
+}
+
+async function simulateReadOnly(
+  server: rpc.Server,
+  contractId: string,
+  sourceAddress: string,
+  method: string,
+  args: xdr.ScVal[] = [],
+  networkPassphrase: string = NETWORK_PASSPHRASE
+): Promise<unknown> {
+  const sourceAccount = await getSourceAccount(server, sourceAddress);
+  const contract = new Contract(contractId);
+  const transaction = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(DEFAULT_TIMEOUT_SECONDS)
+    .build();
+
+  const simulation = await server.simulateTransaction(transaction);
+
+  if (rpc.Api.isSimulationError(simulation)) {
+    throw new Error(`Simulation failed for ${method}: ${simulation.error}`);
+  }
+
+  return getSimulationReturnValue(simulation);
+}
+
+export async function getContractDeadline(
+  contractId: string,
+  landlordAddress: string,
+  deps: ExtendDeadlineDependencies = {}
+): Promise<number> {
+  const retval = await simulateReadOnly(
+    getServer(deps),
+    contractId,
+    landlordAddress,
+    "get_deadline",
+    [],
+    getNetworkPassphrase(deps)
+  );
+
+  return parseEpoch(scValToNative(retval as never));
+}
+
+function isMethodMissing(message: string): boolean {
+  return (
+    message.includes("function does not exist") ||
+    message.includes("unknown function") ||
+    message.includes("method not found") ||
+    message.includes("MissingValue")
+  );
+}
+
+async function resolveExtendMethod(
+  contractId: string,
+  landlordAddress: string,
+  newDeadlineEpoch: number,
+  deps: ExtendDeadlineDependencies
+): Promise<ExtendMethodName> {
+  const candidates = deps.extendMethodCandidates ?? EXTEND_METHOD_CANDIDATES;
+  const server = getServer(deps);
+  const networkPassphrase = getNetworkPassphrase(deps);
+  const landlordArg = Address.fromString(landlordAddress).toScVal();
+  const deadlineArg = nativeToScVal(newDeadlineEpoch, { type: "u64" });
+
+  for (const method of candidates) {
+    try {
+      await simulateReadOnly(
+        server,
+        contractId,
+        landlordAddress,
+        method,
+        [landlordArg, deadlineArg],
+        networkPassphrase
+      );
+      return method;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isMethodMissing(message)) continue;
+      // Non-existence errors (auth, validation) still mean the method exists.
+      return method;
+    }
+  }
+
+  throw new ExtendMethodResolutionError();
+}
+
+function normalizeSignedTransactionXdr(result: FreighterSignResponse): string {
+  const signedXdr = result.signedTxXdr ?? result.txXdr;
+
+  if (typeof signedXdr !== "string" || signedXdr.length === 0) {
+    throw new Error(
+      result.error
+        ? `Failed to sign transaction with Freighter: ${String(result.error)}`
+        : "Freighter did not return a signed transaction XDR."
+    );
+  }
+
+  return signedXdr;
+}
+
+export async function extendDeadline(
+  params: ExtendDeadlineParams,
+  deps: ExtendDeadlineDependencies = {}
+): Promise<ExtendDeadlineResult> {
+  const { contractId, landlordAddress, newDeadlineEpoch } = params;
+
+  if (!Number.isFinite(newDeadlineEpoch) || newDeadlineEpoch <= 0) {
+    throw new Error("New deadline must be a positive Unix timestamp.");
+  }
+
+  const server = getServer(deps);
+  const networkPassphrase = getNetworkPassphrase(deps);
+  const freighter = deps.freighter ?? (await loadFreighterClient());
+
+  const currentDeadlineEpoch =
+    params.currentDeadlineEpoch ??
+    (await getContractDeadline(contractId, landlordAddress, {
+      ...deps,
+      server,
+      networkPassphrase,
+    }));
+
+  if (newDeadlineEpoch <= currentDeadlineEpoch) {
+    throw new DeadlineNotLaterError(currentDeadlineEpoch, newDeadlineEpoch);
+  }
+
+  const connectedAddressResult = await freighter.getAddress();
+  if (connectedAddressResult.error) {
+    throw new Error(
+      `Failed to read connected wallet from Freighter: ${String(
+        connectedAddressResult.error
+      )}`
+    );
+  }
+
+  const connectedAddress = connectedAddressResult.address;
+  if (connectedAddress !== landlordAddress) {
+    throw new Error(
+      `Connected wallet (${connectedAddress.slice(0, 6)}...) does not match expected landlord (${landlordAddress.slice(0, 6)}...).`
+    );
+  }
+
+  const method = await resolveExtendMethod(
+    contractId,
+    landlordAddress,
+    newDeadlineEpoch,
+    { ...deps, server, networkPassphrase }
+  );
+
+  const sourceAccount = await server.getAccount(landlordAddress);
+  const contract = new Contract(contractId);
+
+  const transaction = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(
+      contract.call(
+        method,
+        Address.fromString(landlordAddress).toScVal(),
+        nativeToScVal(newDeadlineEpoch, { type: "u64" })
+      )
+    )
+    .setTimeout(DEFAULT_TIMEOUT_SECONDS)
+    .build();
+
+  const simulation = await server.simulateTransaction(transaction);
+  if (rpc.Api.isSimulationError(simulation)) {
+    throw new Error(`Simulation failed: ${simulation.error}`);
+  }
+
+  const preparedTransaction = rpc.assembleTransaction(transaction, simulation).build();
+  const signedResponse = await freighter.signTransaction(
+    preparedTransaction.toXDR(),
+    {
+      address: landlordAddress,
+      networkPassphrase,
+    }
+  );
+  const signedTxXdr = normalizeSignedTransactionXdr(signedResponse);
+
+  const sendResult = await server.sendTransaction(
+    TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase)
+  );
+
+  if (sendResult.status === "ERROR") {
+    throw new Error(
+      `Transaction submission failed: ${JSON.stringify(
+        sendResult.errorResult ?? sendResult
+      )}`
+    );
+  }
+
+  const wait = deps.sleep ?? sleep;
+  let transactionResult = await server.getTransaction(sendResult.hash);
+  let retries = 0;
+
+  while (
+    transactionResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND &&
+    retries < MAX_CONFIRMATION_RETRIES
+  ) {
+    await wait(CONFIRMATION_DELAY_MS);
+    transactionResult = await server.getTransaction(sendResult.hash);
+    retries += 1;
+  }
+
+  if (transactionResult.status !== rpc.Api.GetTransactionStatus.SUCCESS) {
+    throw new Error(
+      `Transaction did not succeed. Status: ${transactionResult.status}`
+    );
+  }
+
+  return {
+    txHash: sendResult.hash,
+    previousDeadlineEpoch: currentDeadlineEpoch,
+    newDeadlineEpoch,
+    confirmedAt: new Date(transactionResult.createdAt * 1000),
+    method,
+  };
+}

--- a/lib/stellar/queries.ts
+++ b/lib/stellar/queries.ts
@@ -606,6 +606,46 @@ function stroopsToXlm(stroops: string): string {
   return fractionStr.length > 0 ? `${whole}.${fractionStr}` : whole.toString();
 }
 
+// ─── Release approvals ───────────────────────────────────────────────────────
+
+export interface ReleaseApprovalSnapshot {
+  signerAddress: string;
+  approvedAt: Date;
+}
+
+/**
+ * Returns a list of release approvals already collected for the escrow.
+ *
+ * The on-chain release method is a single atomic call rather than a long-lived
+ * vote, so approvals do not live on the contract directly. They are persisted
+ * client-side once a wallet signs the release XDR (see `MultiSigApproval`).
+ *
+ * Callers pass the addresses they have local evidence of approval for; this
+ * helper attaches the canonical timestamp shape `ApprovalStatus` consumes
+ * and filters out unknown signers so the UI never claims a stranger approved.
+ *
+ * Returning a stable, queryable shape from this module keeps the visualization
+ * layer ignorant of where approval evidence is stored (localStorage today,
+ * a backend table tomorrow).
+ */
+export function getReleaseApprovalsForSigners(
+  signerAddresses: string[],
+  approvedAddresses: Iterable<string>,
+  now: Date = new Date()
+): ReleaseApprovalSnapshot[] {
+  const signerSet = new Set(signerAddresses);
+  const seen = new Set<string>();
+  const result: ReleaseApprovalSnapshot[] = [];
+
+  for (const address of approvedAddresses) {
+    if (!signerSet.has(address) || seen.has(address)) continue;
+    seen.add(address);
+    result.push({ signerAddress: address, approvedAt: now });
+  }
+
+  return result;
+}
+
 // ─── User Escrows (Mocked) ───────────────────────────────────────────────────
 
 export async function getUserEscrows(publicKey: string): Promise<ContractState[]> {

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>You're offline — PayEasy</title>
+    <meta
+      name="description"
+      content="PayEasy is offline. Blockchain features require a connection."
+    />
+    <meta name="theme-color" content="#07070a" />
+    <link rel="icon" href="/icons/icon-192.svg" type="image/svg+xml" />
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100%;
+        background: #07070a;
+        color: #f5f5f5;
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          Inter,
+          sans-serif;
+        -webkit-font-smoothing: antialiased;
+      }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background:
+          radial-gradient(
+            circle at 50% 0%,
+            rgba(92, 124, 250, 0.18),
+            transparent 55%
+          ),
+          radial-gradient(
+            circle at 80% 100%,
+            rgba(32, 201, 151, 0.12),
+            transparent 60%
+          ),
+          #07070a;
+      }
+      main {
+        max-width: 440px;
+        width: 100%;
+        text-align: center;
+        padding: 40px 28px;
+        border-radius: 24px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(255, 255, 255, 0.03);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+        box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(255, 255, 255, 0.05);
+        color: #b5c0d6;
+        font-size: 10px;
+        font-weight: 800;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        margin-bottom: 20px;
+      }
+      .icon {
+        width: 56px;
+        height: 56px;
+        margin: 0 auto 20px;
+        border-radius: 18px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(92, 124, 250, 0.14);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #9aa9ff;
+      }
+      h1 {
+        margin: 0 0 12px;
+        font-size: 26px;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+      p {
+        margin: 0 0 24px;
+        font-size: 15px;
+        line-height: 1.6;
+        color: #a0a4af;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        justify-content: center;
+      }
+      button,
+      a.button {
+        appearance: none;
+        border: none;
+        cursor: pointer;
+        padding: 12px 20px;
+        border-radius: 14px;
+        font-size: 12px;
+        font-weight: 900;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        text-decoration: none;
+        transition:
+          transform 0.15s ease,
+          background-color 0.15s ease;
+      }
+      .primary {
+        background: #5c7cfa;
+        color: #fff;
+      }
+      .primary:hover {
+        background: #6c8aff;
+      }
+      .secondary {
+        background: rgba(255, 255, 255, 0.06);
+        color: #f5f5f5;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+      }
+      .secondary:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+      .status {
+        margin-top: 18px;
+        font-size: 11px;
+        color: #6c7282;
+      }
+    </style>
+  </head>
+  <body>
+    <main role="main" aria-labelledby="offline-title">
+      <span class="badge">Connection lost</span>
+      <div class="icon" aria-hidden="true">
+        <svg
+          width="28"
+          height="28"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <line x1="1" y1="1" x2="23" y2="23"></line>
+          <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"></path>
+          <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"></path>
+          <path d="M10.71 5.05A16 16 0 0 1 22.58 9"></path>
+          <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"></path>
+          <path d="M8.53 16.11a6 6 0 0 1 6.95 0"></path>
+          <line x1="12" y1="20" x2="12.01" y2="20"></line>
+        </svg>
+      </div>
+      <h1 id="offline-title">You're offline</h1>
+      <p>
+        Blockchain features require a connection. PayEasy will keep your last
+        viewed pages cached so you can browse what you have already loaded.
+      </p>
+      <div class="actions">
+        <button class="primary" type="button" onclick="window.location.reload()">
+          Try again
+        </button>
+        <a class="button secondary" href="/">Open home</a>
+      </div>
+      <p class="status" id="status" aria-live="polite">
+        We will retry automatically when you come back online.
+      </p>
+    </main>
+    <script>
+      (function () {
+        if (typeof window === "undefined") return;
+        var status = document.getElementById("status");
+        function setStatus(text) {
+          if (status) status.textContent = text;
+        }
+        window.addEventListener("online", function () {
+          setStatus("Connection restored — reloading…");
+          window.location.reload();
+        });
+        window.addEventListener("offline", function () {
+          setStatus("Still offline. We will retry automatically.");
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,3 +1,205 @@
+/* eslint-disable no-restricted-globals */
+
+/**
+ * PayEasy service worker.
+ *
+ * Responsibilities:
+ *   1. Cache the landing page, manifest, icons, and the offline fallback so the
+ *      app renders something useful when the network is unavailable.
+ *   2. Serve cached responses for navigations and static assets when offline,
+ *      falling back to /offline.html for navigations we have never cached.
+ *   3. Broadcast `update-available` to clients when a new worker takes over so
+ *      the UI can offer a refresh.
+ *   4. Preserve the existing web-push behavior (notifications + click-to-open).
+ *
+ * Soroban / Horizon / authenticated API calls are explicitly NOT cached —
+ * blockchain reads must reflect real-time state.
+ */
+
+const CACHE_VERSION = "v1";
+const STATIC_CACHE = `payeasy-static-${CACHE_VERSION}`;
+const RUNTIME_CACHE = `payeasy-runtime-${CACHE_VERSION}`;
+const OFFLINE_URL = "/offline.html";
+
+const STATIC_ASSETS = [
+  "/",
+  OFFLINE_URL,
+  "/manifest.json",
+  "/icons/icon-192.svg",
+  "/icons/icon-512.svg",
+];
+
+function isNavigationRequest(request) {
+  return (
+    request.mode === "navigate" ||
+    (request.method === "GET" &&
+      request.headers.get("accept") &&
+      request.headers.get("accept").includes("text/html"))
+  );
+}
+
+function isCacheableStaticAsset(url) {
+  if (url.origin !== self.location.origin) return false;
+  // Next.js static build output, fonts, public/ assets.
+  return (
+    url.pathname.startsWith("/_next/static/") ||
+    url.pathname.startsWith("/icons/") ||
+    url.pathname.startsWith("/fonts/") ||
+    /\.(?:js|css|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|webp|ico)$/i.test(
+      url.pathname
+    )
+  );
+}
+
+function shouldBypassCache(url) {
+  if (url.origin !== self.location.origin) return true;
+  return (
+    url.pathname.startsWith("/api/") ||
+    url.pathname.startsWith("/_next/data/") ||
+    url.pathname.startsWith("/_next/image")
+  );
+}
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(STATIC_CACHE);
+      // `addAll` is atomic — if any asset 404s the whole install fails. Use
+      // `add` per-entry instead so a missing icon does not break offline.
+      await Promise.all(
+        STATIC_ASSETS.map((asset) =>
+          cache.add(asset).catch(() => {
+            // Asset unavailable at install time; runtime fetch may still cache it.
+          })
+        )
+      );
+      await self.skipWaiting();
+    })()
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter(
+            (key) =>
+              key.startsWith("payeasy-") &&
+              key !== STATIC_CACHE &&
+              key !== RUNTIME_CACHE
+          )
+          .map((key) => caches.delete(key))
+      );
+
+      if (self.registration.navigationPreload) {
+        try {
+          await self.registration.navigationPreload.enable();
+        } catch {
+          // Navigation preload is optional; ignore if unsupported.
+        }
+      }
+
+      await self.clients.claim();
+
+      // Tell open clients a new SW is now controlling them so the UI can
+      // surface an "Update available" banner.
+      const clientsList = await self.clients.matchAll({ type: "window" });
+      for (const client of clientsList) {
+        client.postMessage({ type: "payeasy:update-available" });
+      }
+    })()
+  );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "payeasy:skip-waiting") {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  if (request.method !== "GET") return;
+
+  let url;
+  try {
+    url = new URL(request.url);
+  } catch {
+    return;
+  }
+
+  if (shouldBypassCache(url)) return;
+
+  if (isNavigationRequest(request)) {
+    event.respondWith(handleNavigation(event));
+    return;
+  }
+
+  if (isCacheableStaticAsset(url)) {
+    event.respondWith(handleStaticAsset(request));
+  }
+});
+
+async function handleNavigation(event) {
+  const cache = await caches.open(RUNTIME_CACHE);
+
+  try {
+    const preload = event.preloadResponse
+      ? await event.preloadResponse
+      : null;
+    const networkResponse = preload || (await fetch(event.request));
+
+    if (networkResponse && networkResponse.ok) {
+      cache.put(event.request, networkResponse.clone()).catch(() => undefined);
+    }
+    return networkResponse;
+  } catch {
+    const cached =
+      (await cache.match(event.request)) ||
+      (await caches.match(event.request)) ||
+      (await caches.match("/"));
+    if (cached) return cached;
+
+    const offline = await caches.match(OFFLINE_URL);
+    if (offline) return offline;
+
+    return new Response("Offline", {
+      status: 503,
+      statusText: "Offline",
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}
+
+async function handleStaticAsset(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  try {
+    const networkResponse = await fetch(request);
+    if (networkResponse && networkResponse.ok) {
+      cache.put(request, networkResponse.clone()).catch(() => undefined);
+    }
+    return networkResponse;
+  } catch {
+    // Re-check the cache in case it was filled concurrently, then surface a
+    // structured 503 so the page can decide what to render.
+    const fallback = await cache.match(request);
+    if (fallback) return fallback;
+    return new Response("Offline", {
+      status: 503,
+      statusText: "Offline",
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}
+
+// ─── Push notifications (existing behavior, preserved) ──────────────────────
+
 self.addEventListener("push", (event) => {
   const payload = event.data ? event.data.json() : {};
   const title = payload.title || "PayEasy reminder";


### PR DESCRIPTION
## Summary

Batched implementation of four Wave 5 escrow + PWA issues. Each feature is wired through the existing escrow dashboard and ships behind the contributor's existing patterns (Soroban actions, glass-card components, existing /sw.js).

closes #722
closes #724
closes #725
closes #747

## What's in this PR

### Issue #226 — Escrow: Multi-Signature Approval Visualization (#722)
- New `components/escrow/ApprovalStatus.tsx`: read-only "X of Y approvals received" card with per-signer state, role labels, and a weighted progress bar against the configured threshold.
- Mounted on `app/escrow/[contractId]/EscrowDashboardClient.tsx` above the existing interactive `MultiSigApproval` widget. Approvals state lifted into the page so both components stay in sync.
- New `getReleaseApprovalsForSigners` helper in `lib/stellar/queries.ts` returns a stable approvals snapshot, filtering out any address that is not a configured signer.
- Vitest coverage: headline math, unknown-signer filtering, threshold-satisfied transition.

### Issue #228 — Escrow: Deadline Extension Request Flow (#724)
- New `components/escrow/ExtendDeadlineModal.tsx`: landlord-only datetime picker that enforces a strictly later deadline (minimum +1 hour) before invoking the action. Reset on every open so stale form values do not linger.
- New `lib/stellar/actions/extendDeadline.ts`: mirrors `claimRefund` / `release` structure — reads the on-chain deadline, validates strictly-later, confirms the connected wallet matches the landlord, then builds, signs, submits, and confirms the Soroban call. Resolves against `extend_deadline` / `update_deadline` / `set_deadline` so a contract rename does not break the frontend.
- Dashboard: new "Request Extension" button in the landlord control strip; on success the dashboard refreshes contract state and shows a dismissible aria-live banner notifying every viewer of the new deadline (satisfies the "notify all roommates" acceptance criterion).
- Vitest coverage: rejects non-finite epoch, throws `DeadlineNotLaterError` when not strictly later, rejects when connected wallet is not the landlord — all without touching the network (uses the injectable `freighter` dep).

### Issue #229 — Escrow: Refund Preview Before Claiming (#725)
- New `components/escrow/RefundPreview.tsx`: pure component that converts the on-chain `paid_amount` (stroops) to XLM, labels it as the roommate's full contribution by default, and explicitly clarifies that Stellar gas fees will be deducted from the wallet on submission.
- Mounted on the dashboard immediately above the existing "Refund Available" card when `showClaimRefundButton` is true and a current roommate is present.
- Vitest coverage: whole + fractional XLM precision, gas-fee disclosure copy, defensive handling of malformed input (renders 0 XLM rather than crashing the dashboard), and an optional custom label for partial-refund scenarios.

### Issue #251 — PWA: Service Worker for Offline Support (#747)
- `public/sw.js`: precaches the landing page, manifest, icons, and the new `/offline.html` on install; cache-first for static assets, network-first with offline fallback for navigations. Soroban / Horizon / `/api/*` are explicitly bypassed so blockchain reads never serve stale data. The existing web-push handlers (`push`, `notificationclick`) are preserved exactly.
- `public/offline.html`: standalone, themed offline fallback that auto-reloads when the device comes back online, with retry + home links.
- `components/ui/service-worker-manager.tsx`: idempotent client-side registration mounted from `AppShell`. Skipped in development. Listens for `controllerchange` / waiting workers and surfaces an aria-live "Update available" banner with a Refresh now button that posts `payeasy:skip-waiting` and reloads.
- Acceptance criterion: disabling network in DevTools now renders `/offline.html` instead of a blank chrome error.

## Notes / disclosures

- **Issue #251 deviation from suggested files**: the issue lists `next.config.js (add next-pwa)`. The repo already maintains a hand-written `public/sw.js` for push reminders, so adding `next-pwa` would mean two registration paths competing for `/sw.js`. I extended the existing worker instead. Happy to switch to `next-pwa` if maintainers prefer — the offline fallback page would still be the same.
- **TypeScript / build verification**: I could not run `tsc` / `npm run build` locally in the sandbox. Types were matched by hand against the existing actions (`release.ts`, `claimRefund.ts`, `contribute.ts`). CI on this PR is the source of truth.
- **Pre-existing issue noticed**: `app/escrow/[contractId]/EscrowDashboardClient.tsx` on `main` references undefined `preferences`, `Clock`, `CheckCircle2`, and `RefreshCcw` symbols (lines ~273–322). That code is unchanged by this PR — flagging in case CI is currently red because of it.

## Test plan

- [ ] CI green on the new vitest files (`ApprovalStatus.test.tsx`, `RefundPreview.test.tsx`, `__tests__/extendDeadline.test.ts`, `__tests__/getReleaseApprovalsForSigners.test.ts`).
- [ ] Visit `/escrow/<contractId>`: ApprovalStatus card renders above MultiSigApproval, headline updates as the mock-mode approvals widget collects signatures.
- [ ] As landlord: click Request Extension, pick a date strictly after the current one, confirm in Freighter, see the green "Deadline extended to …" banner and updated countdown.
- [ ] As a roommate past the deadline on an under-funded escrow: see "You will receive back X XLM …" above the Claim Refund button.
- [ ] DevTools → Network → Offline → reload `/`: offline.html renders. Re-enable network: the page auto-reloads.
- [ ] Deploy a new SW version → confirm the "Update available" banner appears for active clients.