### PR TITLE
Add mobile UX: iOS date sheet, swipe actions, native share

### DIFF
--- a/app/escrows/page.tsx
+++ b/app/escrows/page.tsx
@@ -3,14 +3,24 @@
 import { useEffect, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Wallet, Clock, ArrowRight, ShieldCheck, AlertCircle, Archive, ArchiveRestore } from "lucide-react";
-import { useStellarAuth } from "@/context/StellarContext";
-import { Wallet, Clock, ArrowRight, ShieldCheck, AlertCircle, FileText, PlusCircle } from "lucide-react";
+import {
+  Wallet,
+  Clock,
+  ArrowRight,
+  ShieldCheck,
+  AlertCircle,
+  Archive,
+  ArchiveRestore,
+  FileText,
+  PlusCircle,
+} from "lucide-react";
 import { useStellar } from "@/context/StellarContext";
 import { getUserEscrows } from "@/lib/stellar/queries";
 import { useArchivedEscrows } from "@/hooks/useArchivedEscrows";
 import type { ContractState } from "@/lib/stellar/types";
 import RoommateEscrowCard from "@/components/escrow/RoommateEscrowCard";
+import SwipeableEscrowCard from "@/components/escrow/SwipeableEscrowCard";
+import ShareEscrowModal from "@/components/escrow/ShareEscrowModal";
 
 const ARCHIVABLE_STATUSES: ContractState["status"][] = ["released", "expired"];
 
@@ -21,6 +31,7 @@ export default function EscrowsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showArchived, setShowArchived] = useState(false);
+  const [shareContractId, setShareContractId] = useState<string | null>(null);
 
   const { archiveEscrow, unarchiveEscrow, isArchived } = useArchivedEscrows();
   const [roleTab, setRoleTab] = useState<"landlord" | "roommate">("landlord");
@@ -48,47 +59,11 @@ export default function EscrowsPage() {
     }
   }, [isConnected, publicKey, isRestoring, router]);
 
-  // Separate escrows based on role
   const landlordEscrows = useMemo(() => {
     if (!publicKey) return [];
     return escrows.filter((escrow) => escrow.landlord === publicKey);
   }, [escrows, publicKey]);
 
-  const visibleEscrows = escrows.filter((e) =>
-    showArchived ? isArchived(e.id) : !isArchived(e.id)
-  );
-
-  const archivedCount = escrows.filter((e) => isArchived(e.id)).length;
-
-  return (
-    <main aria-label="User Escrows" className="container mx-auto max-w-5xl px-4 py-32 space-y-8 min-h-screen">
-      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
-            Your Escrows
-          </h1>
-          <p className="text-gray-500 dark:text-gray-400 mt-2">
-            Manage and view all rent agreements associated with your wallet.
-          </p>
-        </div>
-        <div className="flex items-center gap-3 shrink-0">
-          {archivedCount > 0 && (
-            <button
-              onClick={() => setShowArchived((prev) => !prev)}
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/10 transition-colors"
-            >
-              <Archive className="w-4 h-4" />
-              {showArchived ? "Show active" : `Show archived (${archivedCount})`}
-            </button>
-          )}
-          <Link
-            href="/escrow/create"
-            className="btn-primary !py-2.5 !px-5 !text-sm !rounded-lg"
-          >
-            Create Escrow
-          </Link>
-        </div>
-      </div>
   const roommateEscrows = useMemo(() => {
     if (!publicKey) return [];
     return escrows.filter((escrow) =>
@@ -96,124 +71,27 @@ export default function EscrowsPage() {
     );
   }, [escrows, publicKey]);
 
-  const activeEscrowsList = roleTab === "landlord" ? landlordEscrows : roommateEscrows;
+  const roleEscrows = roleTab === "landlord" ? landlordEscrows : roommateEscrows;
 
-      {loading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="glass-card p-6 h-48 animate-pulse bg-white/5" />
-          ))}
-        </div>
-      ) : visibleEscrows.length === 0 ? (
-        <div className="glass-card p-12 text-center flex flex-col items-center justify-center space-y-4">
-          <div className="w-16 h-16 rounded-full bg-brand-500/10 flex items-center justify-center mb-2">
-            {showArchived ? (
-              <Archive className="w-8 h-8 text-brand-400" />
-            ) : (
-              <Wallet className="w-8 h-8 text-brand-400" />
-            )}
-          </div>
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white">
-            {showArchived ? "No archived escrows" : "No escrows found"}
-          </h2>
-          <p className="text-gray-500 dark:text-gray-400 max-w-md mx-auto">
-            {showArchived
-              ? "Archived escrows will appear here."
-              : "You don’t have any active or funded escrow agreements connected to this wallet yet."}
-          </p>
-          {!showArchived && (
-            <Link href="/escrow/create" className="btn-primary mt-4">
-              Create Your First Escrow
-            </Link>
-          )}
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {visibleEscrows.map((escrow) => (
-            <div key={escrow.id} className="glass-card p-6 hover:-translate-y-1 transition-transform duration-300 group">
-              <div className="flex items-start justify-between mb-6">
-                <div>
-                  <h3 className="font-mono text-sm font-semibold text-brand-400 mb-1">
-                    {escrow.id}
-                  </h3>
-                  <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-                    <Clock className="w-3.5 h-3.5" />
-                    Deadline: {escrow.deadline}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  {escrow.status === "funded" ? (
-                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-500 dark:text-emerald-400 text-xs font-bold uppercase tracking-wider border border-emerald-500/20">
-                      <ShieldCheck className="w-3.5 h-3.5" />
-                      Funded
-                    </span>
-                  ) : escrow.status === "released" ? (
-                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-blue-500/10 text-blue-500 dark:text-blue-400 text-xs font-bold uppercase tracking-wider border border-blue-500/20">
-                      <ShieldCheck className="w-3.5 h-3.5" />
-                      Released
-                    </span>
-                  ) : escrow.status === "expired" ? (
-                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-gray-500/10 text-gray-500 dark:text-gray-400 text-xs font-bold uppercase tracking-wider border border-gray-500/20">
-                      <Clock className="w-3.5 h-3.5" />
-                      Expired
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-bold uppercase tracking-wider border border-amber-500/20">
-                      <Clock className="w-3.5 h-3.5" />
-                      Active
-                    </span>
-                  )}
-                  {ARCHIVABLE_STATUSES.includes(escrow.status) && (
-                    isArchived(escrow.id) ? (
-                      <button
-                        onClick={() => unarchiveEscrow(escrow.id)}
-                        title="Unarchive escrow"
-                        className="p-1.5 rounded-lg text-gray-400 hover:text-brand-400 hover:bg-white/10 transition-colors"
-                      >
-                        <ArchiveRestore className="w-4 h-4" />
-                      </button>
-                    ) : (
-                      <button
-                        onClick={() => archiveEscrow(escrow.id)}
-                        title="Archive escrow"
-                        className="p-1.5 rounded-lg text-gray-400 hover:text-brand-400 hover:bg-white/10 transition-colors"
-                      >
-                        <Archive className="w-4 h-4" />
-                      </button>
-                    )
-                  )}
-                </div>
-              </div>
+  const visibleEscrows = roleEscrows.filter((e) =>
+    showArchived ? isArchived(e.id) : !isArchived(e.id)
+  );
 
-              <div className="space-y-4 mb-6">
-                <div>
-                  <div className="flex justify-between text-sm mb-2">
-                    <span className="text-gray-500 dark:text-gray-400">Progress</span>
-                    <span className="text-brand-600 dark:text-brand-400 font-bold">
-                      {Math.round((escrow.totalFunded / Number(escrow.totalRent)) * 100)}% Funded
-                    </span>
-                  </div>
-                  <div className="h-2 w-full bg-gray-200 dark:bg-white/10 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-gradient-to-r from-brand-500 to-accent-500"
-                      style={{ width: `${Math.min(100, Math.round((escrow.totalFunded / Number(escrow.totalRent)) * 100))}%` }}
-                    />
-                  </div>
-                </div>
+  const archivedCount = roleEscrows.filter((e) => isArchived(e.id)).length;
 
-                <div className="grid grid-cols-2 gap-4 pt-4 border-t border-gray-100 dark:border-white/5">
-                  <div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Total Rent</div>
-                    <div className="text-lg font-semibold text-gray-900 dark:text-white">{escrow.totalRent} XLM</div>
-                  </div>
-                  <div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Funded</div>
-                    <div className="text-lg font-semibold text-gray-900 dark:text-white">{escrow.totalFunded} XLM</div>
   if (isRestoring || (!isConnected && !publicKey)) return null;
 
   return (
     <main aria-label="User Escrows" className="min-h-screen pt-32 pb-24 relative overflow-hidden bg-[#07070a]">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(92,124,250,0.1),transparent_50%)] pointer-events-none" />
+
+      {shareContractId && (
+        <ShareEscrowModal
+          contractId={shareContractId}
+          isOpen
+          onClose={() => setShareContractId(null)}
+        />
+      )}
 
       <div className="container relative z-10 mx-auto px-6 max-w-5xl space-y-12">
         <header className="flex flex-col md:flex-row md:items-end justify-between gap-6">
@@ -230,13 +108,25 @@ export default function EscrowsPage() {
             </p>
           </div>
 
-          <Link
-            href="/escrow/create"
-            className="btn-primary !py-3 !px-6 !rounded-xl font-black uppercase tracking-widest flex items-center gap-2 shrink-0 self-start md:self-auto"
-          >
-            <PlusCircle className="h-4 w-4" />
-            Create Escrow
-          </Link>
+          <div className="flex items-center gap-3 shrink-0 self-start md:self-auto">
+            {archivedCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowArchived((prev) => !prev)}
+                className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-white/10 bg-white/5 text-xs font-black uppercase tracking-widest text-dark-300 hover:bg-white/10 transition-colors"
+              >
+                <Archive className="w-4 h-4" />
+                {showArchived ? "Show active" : `Archived (${archivedCount})`}
+              </button>
+            )}
+            <Link
+              href="/escrow/create"
+              className="btn-primary !py-3 !px-6 !rounded-xl font-black uppercase tracking-widest flex items-center gap-2"
+            >
+              <PlusCircle className="h-4 w-4" />
+              Create Escrow
+            </Link>
+          </div>
         </header>
 
         {error && (
@@ -246,9 +136,9 @@ export default function EscrowsPage() {
           </div>
         )}
 
-        {/* Role Tab Selection */}
         <div className="flex border-b border-white/10 gap-6 text-sm">
           <button
+            type="button"
             onClick={() => setRoleTab("landlord")}
             className={`pb-4 font-black uppercase tracking-widest transition-all text-xs ${
               roleTab === "landlord"
@@ -259,6 +149,7 @@ export default function EscrowsPage() {
             As Landlord
           </button>
           <button
+            type="button"
             onClick={() => setRoleTab("roommate")}
             className={`pb-4 font-black uppercase tracking-widest transition-all text-xs ${
               roleTab === "roommate"
@@ -276,39 +167,58 @@ export default function EscrowsPage() {
               <div key={i} className="glass-card p-6 h-56 animate-pulse bg-white/5" />
             ))}
           </div>
-        ) : activeEscrowsList.length === 0 ? (
+        ) : visibleEscrows.length === 0 ? (
           <div className="glass-card p-12 text-center flex flex-col items-center justify-center space-y-4 border border-white/5">
             <div className="w-16 h-16 rounded-full bg-brand-500/10 flex items-center justify-center mb-2">
-              <Wallet className="w-8 h-8 text-brand-400" />
+              {showArchived ? (
+                <Archive className="w-8 h-8 text-brand-400" />
+              ) : (
+                <Wallet className="w-8 h-8 text-brand-400" />
+              )}
             </div>
-            <h2 className="text-xl font-black text-white uppercase tracking-wider">No escrows found</h2>
+            <h2 className="text-xl font-black text-white uppercase tracking-wider">
+              {showArchived ? "No archived escrows" : "No escrows found"}
+            </h2>
             <p className="text-dark-400 text-sm max-w-md mx-auto">
-              You don&apos;t have any active or funded escrow agreements as a {roleTab === "landlord" ? "landlord" : "roommate"} connected to this wallet yet.
+              {showArchived
+                ? "Archived escrows will appear here."
+                : `You don't have any escrow agreements as a ${roleTab === "landlord" ? "landlord" : "roommate"} connected to this wallet yet.`}
             </p>
+            {!showArchived && (
+              <Link href="/escrow/create" className="btn-primary mt-4">
+                Create Your First Escrow
+              </Link>
+            )}
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {activeEscrowsList.map((escrow) => {
+            {visibleEscrows.map((escrow) => {
+              const canArchive =
+                ARCHIVABLE_STATUSES.includes(escrow.status) && !isArchived(escrow.id);
+              const canUnarchive = isArchived(escrow.id);
+
               if (roleTab === "roommate") {
                 const myRoommateState = escrow.roommates.find(
                   (r) => r.address === publicKey
                 )!;
                 return (
-                  <RoommateEscrowCard
+                  <SwipeableEscrowCard
                     key={escrow.id}
-                    escrow={escrow}
-                    roommate={myRoommateState}
-                  />
+                    onShare={() => setShareContractId(escrow.id)}
+                    canArchive={false}
+                  >
+                    <RoommateEscrowCard escrow={escrow} roommate={myRoommateState} />
+                  </SwipeableEscrowCard>
                 );
               }
 
-              // Landlord view card
               const percentage = Math.min(
                 100,
                 Math.round((escrow.totalFunded / Number(escrow.totalRent)) * 100)
               );
-              return (
-                <div key={escrow.id} className="glass-card p-6 flex flex-col justify-between gap-6 hover:-translate-y-1 transition-all duration-300 group border border-white/5 bg-white/[0.02]">
+
+              const card = (
+                <div className="glass-card p-6 flex flex-col justify-between gap-6 hover:-translate-y-1 transition-all duration-300 group border border-white/5 bg-white/[0.02]">
                   <div className="space-y-6">
                     <div className="flex justify-between items-start">
                       <div>
@@ -320,11 +230,21 @@ export default function EscrowsPage() {
                           Deadline: {escrow.deadline}
                         </div>
                       </div>
-                      <div>
+                      <div className="flex items-center gap-2">
                         {escrow.status === "funded" ? (
                           <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-500 dark:text-emerald-400 text-xs font-bold uppercase tracking-wider border border-emerald-500/20">
                             <ShieldCheck className="w-3.5 h-3.5" />
                             Funded
+                          </span>
+                        ) : escrow.status === "released" ? (
+                          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-blue-500/10 text-blue-500 dark:text-blue-400 text-xs font-bold uppercase tracking-wider border border-blue-500/20">
+                            <ShieldCheck className="w-3.5 h-3.5" />
+                            Released
+                          </span>
+                        ) : escrow.status === "expired" ? (
+                          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-gray-500/10 text-gray-500 dark:text-gray-400 text-xs font-bold uppercase tracking-wider border border-gray-500/20">
+                            <Clock className="w-3.5 h-3.5" />
+                            Expired
                           </span>
                         ) : (
                           <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-bold uppercase tracking-wider border border-amber-500/20">
@@ -332,29 +252,45 @@ export default function EscrowsPage() {
                             Active
                           </span>
                         )}
+                        {canUnarchive && (
+                          <button
+                            type="button"
+                            onClick={() => unarchiveEscrow(escrow.id)}
+                            title="Unarchive escrow"
+                            className="p-1.5 rounded-lg text-gray-400 hover:text-brand-400 hover:bg-white/10 transition-colors"
+                          >
+                            <ArchiveRestore className="w-4 h-4" />
+                          </button>
+                        )}
                       </div>
                     </div>
 
                     <div className="space-y-2">
                       <div className="flex justify-between text-xs">
-                        <span className="text-dark-500 font-bold uppercase tracking-wider">Overall Progress</span>
+                        <span className="text-dark-500 font-bold uppercase tracking-wider">
+                          Overall Progress
+                        </span>
                         <span className="text-brand-400 font-bold">{percentage}% Funded</span>
                       </div>
                       <div className="h-2 w-full bg-white/5 rounded-full overflow-hidden">
-                        <div 
-                          className="h-full bg-gradient-to-r from-brand-500 to-accent-500" 
+                        <div
+                          className="h-full bg-gradient-to-r from-brand-500 to-accent-500"
                           style={{ width: `${percentage}%` }}
                         />
                       </div>
                     </div>
-                    
+
                     <div className="grid grid-cols-2 gap-4 pt-4 border-t border-white/5">
                       <div>
-                        <div className="text-[9px] text-dark-500 font-black uppercase tracking-wider mb-1">Total Rent</div>
+                        <div className="text-[9px] text-dark-500 font-black uppercase tracking-wider mb-1">
+                          Total Rent
+                        </div>
                         <div className="text-sm font-bold text-white">{escrow.totalRent} XLM</div>
                       </div>
                       <div>
-                        <div className="text-[9px] text-dark-500 font-black uppercase tracking-wider mb-1">Funded So Far</div>
+                        <div className="text-[9px] text-dark-500 font-black uppercase tracking-wider mb-1">
+                          Funded So Far
+                        </div>
                         <div className="text-sm font-bold text-white">{escrow.totalFunded} XLM</div>
                       </div>
                     </div>
@@ -364,9 +300,23 @@ export default function EscrowsPage() {
                     href={`/escrow/${escrow.id}`}
                     className="flex items-center justify-center w-full gap-2 py-3 bg-white/5 hover:bg-white/10 text-white rounded-xl transition-colors font-black uppercase tracking-widest text-xs border border-white/5"
                   >
-                    View Escrow <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
+                    View Escrow{" "}
+                    <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 </div>
+              );
+
+              return (
+                <SwipeableEscrowCard
+                  key={escrow.id}
+                  onShare={() => setShareContractId(escrow.id)}
+                  onArchive={
+                    canArchive ? () => archiveEscrow(escrow.id) : undefined
+                  }
+                  canArchive={canArchive}
+                >
+                  {card}
+                </SwipeableEscrowCard>
               );
             })}
           </div>

--- a/components/escrow/ShareEscrowModal.tsx
+++ b/components/escrow/ShareEscrowModal.tsx
@@ -101,7 +101,9 @@ export default function ShareEscrowModal({
               </div>
               <h2 className="text-xl font-black text-white">Payment Link</h2>
               <p className="text-dark-400 text-sm leading-relaxed">
-                Scan the QR code or copy the link to share this escrow with your roommates.
+                {canShare
+                  ? "Scan the QR code or use Share to send this escrow link to your roommates."
+                  : "Scan the QR code or copy the link to share this escrow with your roommates."}
               </p>
             </div>
 
@@ -124,44 +126,75 @@ export default function ShareEscrowModal({
               <span className="text-dark-300 text-xs font-mono truncate flex-1">
                 {shareUrl}
               </span>
-              <button
-                onClick={() => void handleCopy()}
-                aria-label="Copy link"
-                className="shrink-0 p-1.5 rounded-lg text-dark-400 hover:text-brand-400 hover:bg-white/5 transition-all"
-              >
-                <AnimatePresence mode="wait" initial={false}>
-                  {copied ? (
-                    <motion.div
-                      key="check"
-                      initial={{ opacity: 0, scale: 0.5 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 0.5 }}
-                      transition={{ duration: 0.15 }}
-                    >
-                      <Check className="h-4 w-4 text-accent-400" />
-                    </motion.div>
-                  ) : (
-                    <motion.div
-                      key="copy"
-                      initial={{ opacity: 0, scale: 0.5 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 0.5 }}
-                      transition={{ duration: 0.15 }}
-                    >
-                      <Copy className="h-4 w-4" />
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </button>
+              {!canShare && (
+                <button
+                  onClick={() => void handleCopy()}
+                  aria-label="Copy link"
+                  className="shrink-0 p-1.5 rounded-lg text-dark-400 hover:text-brand-400 hover:bg-white/5 transition-all"
+                >
+                  <AnimatePresence mode="wait" initial={false}>
+                    {copied ? (
+                      <motion.div
+                        key="check"
+                        initial={{ opacity: 0, scale: 0.5 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.5 }}
+                        transition={{ duration: 0.15 }}
+                      >
+                        <Check className="h-4 w-4 text-accent-400" />
+                      </motion.div>
+                    ) : (
+                      <motion.div
+                        key="copy"
+                        initial={{ opacity: 0, scale: 0.5 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.5 }}
+                        transition={{ duration: 0.15 }}
+                      >
+                        <Copy className="h-4 w-4" />
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </button>
+              )}
             </div>
 
-            {canShare && (
+            {canShare ? (
               <button
                 onClick={() => void handleNativeShare()}
                 className="btn-primary w-full !py-3 !rounded-xl font-black uppercase tracking-widest flex items-center justify-center gap-2"
               >
                 <Share2 className="h-4 w-4" />
                 Share
+              </button>
+            ) : (
+              <button
+                onClick={() => void handleCopy()}
+                className="btn-primary w-full !py-3 !rounded-xl font-black uppercase tracking-widest flex items-center justify-center gap-2"
+              >
+                <AnimatePresence mode="wait" initial={false}>
+                  {copied ? (
+                    <motion.span
+                      key="copied"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      className="flex items-center gap-2"
+                    >
+                      <Check className="h-4 w-4" />
+                      Copied!
+                    </motion.span>
+                  ) : (
+                    <motion.span
+                      key="copy"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      className="flex items-center gap-2"
+                    >
+                      <Copy className="h-4 w-4" />
+                      Copy Link
+                    </motion.span>
+                  )}
+                </AnimatePresence>
               </button>
             )}
           </motion.div>

--- a/components/escrow/SwipeableEscrowCard.tsx
+++ b/components/escrow/SwipeableEscrowCard.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useRef } from "react";
+import { motion, useMotionValue, useTransform, animate, type PanInfo } from "framer-motion";
+import { Archive, Share2 } from "lucide-react";
+
+const REVEAL_THRESHOLD = 80;
+const ARCHIVE_THRESHOLD = 200;
+const ACTION_BUTTON_WIDTH = 72;
+
+interface SwipeableEscrowCardProps {
+  children: React.ReactNode;
+  onArchive?: () => void;
+  onShare?: () => void;
+  /** When false, only Share is shown (if provided). */
+  canArchive?: boolean;
+}
+
+export default function SwipeableEscrowCard({
+  children,
+  onArchive,
+  onShare,
+  canArchive = true,
+}: SwipeableEscrowCardProps) {
+  const x = useMotionValue(0);
+  const actionsOpacity = useTransform(x, [0, -REVEAL_THRESHOLD], [0, 1]);
+  const isDragging = useRef(false);
+
+  function snapTo(target: number) {
+    void animate(x, target, { type: "spring", stiffness: 400, damping: 35 });
+  }
+
+  function handleDragEnd(_: unknown, info: PanInfo) {
+    isDragging.current = false;
+    const offset = info.offset.x;
+
+    if (offset <= -ARCHIVE_THRESHOLD && canArchive && onArchive) {
+      onArchive();
+      snapTo(0);
+      return;
+    }
+
+    if (offset <= -REVEAL_THRESHOLD) {
+      snapTo(-actionsWidth);
+      return;
+    }
+
+    snapTo(0);
+  }
+
+  const showArchive = canArchive && !!onArchive;
+  const showShare = !!onShare;
+  const actionsWidth =
+    (showArchive ? ACTION_BUTTON_WIDTH : 0) + (showShare ? ACTION_BUTTON_WIDTH : 0);
+
+  if (!showArchive && !showShare) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl touch-pan-y">
+      <motion.div
+        className="absolute inset-y-0 right-0 flex items-stretch"
+        style={{ opacity: actionsOpacity, width: actionsWidth }}
+        aria-hidden
+      >
+        {showArchive && (
+          <button
+            type="button"
+            onClick={() => {
+              onArchive?.();
+              snapTo(0);
+            }}
+            className="flex w-[72px] flex-col items-center justify-center gap-1 bg-dark-700 text-white text-[10px] font-black uppercase tracking-wider"
+            aria-label="Archive escrow"
+          >
+            <Archive className="h-5 w-5" />
+            Archive
+          </button>
+        )}
+        {showShare && (
+          <button
+            type="button"
+            onClick={() => {
+              onShare?.();
+              snapTo(0);
+            }}
+            className="flex w-[72px] flex-col items-center justify-center gap-1 bg-brand-600 text-white text-[10px] font-black uppercase tracking-wider"
+            aria-label="Share escrow"
+          >
+            <Share2 className="h-5 w-5" />
+            Share
+          </button>
+        )}
+      </motion.div>
+
+      <motion.div
+        drag="x"
+        dragConstraints={{ left: -actionsWidth, right: 0 }}
+        dragElastic={{ left: 0.1, right: 0 }}
+        style={{ x }}
+        onDragStart={() => {
+          isDragging.current = true;
+        }}
+        onDragEnd={handleDragEnd}
+        className="relative z-10 cursor-grab active:cursor-grabbing"
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}

--- a/components/ui/date-input.tsx
+++ b/components/ui/date-input.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
-import { CalendarDays } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { CalendarDays, ChevronDown } from "lucide-react";
 import { FieldError, fieldBorderClass } from "@/components/ui/field-error";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { detectIOS } from "@/lib/platform/is-ios";
 import {
   formatDeadlineDisplay,
   getTomorrowIso,
@@ -18,6 +20,212 @@ interface DateInputProps {
   "aria-describedby"?: string;
 }
 
+const DISPLAY_MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+function parseIso(iso: string): { year: number; month: number; day: number } | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return { year, month, day };
+}
+
+function toIso(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function buildSelectableDates(minIso: string, yearsAhead = 5): string[] {
+  const min = parseIso(minIso);
+  if (!min) return [];
+
+  const dates: string[] = [];
+  const endYear = min.year + yearsAhead;
+
+  for (let year = min.year; year <= endYear; year++) {
+    const startMonth = year === min.year ? min.month : 1;
+    const endMonth = 12;
+    for (let month = startMonth; month <= endMonth; month++) {
+      const startDay = year === min.year && month === min.month ? min.day : 1;
+      const lastDay = daysInMonth(year, month);
+      for (let day = startDay; day <= lastDay; day++) {
+        dates.push(toIso(year, month, day));
+      }
+    }
+  }
+  return dates;
+}
+
+function IosDatePickerSheet({
+  id,
+  value,
+  minIso,
+  onChange,
+  isOpen,
+  onClose,
+}: {
+  id: string;
+  value: string;
+  minIso: string;
+  onChange: (value: string) => void;
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  const selectableDates = useMemo(() => buildSelectableDates(minIso), [minIso]);
+  const minParsed = parseIso(minIso);
+  const initial = parseIso(value) ?? minParsed;
+
+  const [year, setYear] = useState(initial?.year ?? minParsed?.year ?? new Date().getUTCFullYear());
+  const [month, setMonth] = useState(initial?.month ?? minParsed?.month ?? 1);
+  const [day, setDay] = useState(initial?.day ?? minParsed?.day ?? 1);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const parsed = parseIso(value) ?? minParsed;
+    if (parsed) {
+      setYear(parsed.year);
+      setMonth(parsed.month);
+      setDay(parsed.day);
+    }
+  }, [isOpen, value, minParsed]);
+
+  const years = useMemo(() => {
+    if (!minParsed) return [];
+    const end = minParsed.year + 5;
+    return Array.from({ length: end - minParsed.year + 1 }, (_, i) => minParsed.year + i);
+  }, [minParsed]);
+
+  const months = useMemo(() => {
+    if (!minParsed) return [];
+    const start = year === minParsed.year ? minParsed.month : 1;
+    return Array.from({ length: 12 - start + 1 }, (_, i) => start + i);
+  }, [minParsed, year]);
+
+  const days = useMemo(() => {
+    if (!minParsed) return [];
+    const last = daysInMonth(year, month);
+    const start =
+      year === minParsed.year && month === minParsed.month ? minParsed.day : 1;
+    return Array.from({ length: last - start + 1 }, (_, i) => start + i);
+  }, [minParsed, year, month]);
+
+  useEffect(() => {
+    if (!months.includes(month)) setMonth(months[0] ?? month);
+  }, [months, month]);
+
+  useEffect(() => {
+    if (!days.includes(day)) setDay(days[0] ?? day);
+  }, [days, day]);
+
+  const selectedIso = toIso(year, month, day);
+  const isValid = selectableDates.includes(selectedIso);
+
+  function handleConfirm() {
+    if (isValid) {
+      onChange(selectedIso);
+      onClose();
+    }
+  }
+
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onClose} title="Select deadline">
+      <div className="space-y-5 px-3">
+        <div className="grid grid-cols-3 gap-3">
+          <div className="space-y-1.5">
+            <label htmlFor={`${id}-ios-month`} className="text-[10px] font-black uppercase tracking-widest text-dark-500">
+              Month
+            </label>
+            <select
+              id={`${id}-ios-month`}
+              value={month}
+              onChange={(e) => setMonth(Number(e.target.value))}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-2 py-3 text-sm text-white focus:border-brand-400 focus:outline-none"
+            >
+              {months.map((m) => (
+                <option key={m} value={m} className="bg-[#111118]">
+                  {DISPLAY_MONTHS[m - 1]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor={`${id}-ios-day`} className="text-[10px] font-black uppercase tracking-widest text-dark-500">
+              Day
+            </label>
+            <select
+              id={`${id}-ios-day`}
+              value={day}
+              onChange={(e) => setDay(Number(e.target.value))}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-2 py-3 text-sm text-white focus:border-brand-400 focus:outline-none"
+            >
+              {days.map((d) => (
+                <option key={d} value={d} className="bg-[#111118]">
+                  {d}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor={`${id}-ios-year`} className="text-[10px] font-black uppercase tracking-widest text-dark-500">
+              Year
+            </label>
+            <select
+              id={`${id}-ios-year`}
+              value={year}
+              onChange={(e) => setYear(Number(e.target.value))}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-2 py-3 text-sm text-white focus:border-brand-400 focus:outline-none"
+            >
+              {years.map((y) => (
+                <option key={y} value={y} className="bg-[#111118]">
+                  {y}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <p className="text-center text-sm text-brand-200 font-medium">
+          {formatDeadlineDisplay(selectedIso) || "Select a date"}
+        </p>
+
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={!isValid}
+          className="btn-primary w-full !py-3 !rounded-xl font-black uppercase tracking-widest disabled:opacity-50"
+        >
+          Confirm date
+        </button>
+      </div>
+    </BottomSheet>
+  );
+}
+
 export function DateInput({
   id,
   value,
@@ -31,6 +239,13 @@ export function DateInput({
   const errorId = error ? `${id}-error` : undefined;
   const describedBy = [errorId, ariaDescribedBy].filter(Boolean).join(" ") || undefined;
 
+  const [isIOS, setIsIOS] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  useEffect(() => {
+    setIsIOS(detectIOS());
+  }, []);
+
   return (
     <div className="space-y-2">
       <div
@@ -42,17 +257,45 @@ export function DateInput({
         >
           <CalendarDays size={18} />
         </span>
-        <input
-          id={id}
-          type="date"
-          value={value}
-          min={minIso}
-          onChange={(event) => onChange(event.target.value)}
-          aria-describedby={describedBy}
-          aria-invalid={!!error}
-          data-testid="deadline-date-input"
-          className="w-full bg-transparent px-3 py-3 text-dark-100 placeholder:text-dark-600 focus:outline-none [color-scheme:dark]"
-        />
+
+        {isIOS ? (
+          <>
+            <button
+              type="button"
+              id={id}
+              onClick={() => setSheetOpen(true)}
+              aria-describedby={describedBy}
+              aria-invalid={!!error}
+              data-testid="deadline-date-input"
+              className="flex w-full items-center justify-between bg-transparent px-3 py-3 text-left text-dark-100 focus:outline-none"
+            >
+              <span className={formatted ? "text-dark-100" : "text-dark-600"}>
+                {formatted || "Select deadline date"}
+              </span>
+              <ChevronDown className="h-4 w-4 shrink-0 text-dark-500" aria-hidden="true" />
+            </button>
+            <IosDatePickerSheet
+              id={id}
+              value={value}
+              minIso={minIso}
+              onChange={onChange}
+              isOpen={sheetOpen}
+              onClose={() => setSheetOpen(false)}
+            />
+          </>
+        ) : (
+          <input
+            id={id}
+            type="date"
+            value={value}
+            min={minIso}
+            onChange={(event) => onChange(event.target.value)}
+            aria-describedby={describedBy}
+            aria-invalid={!!error}
+            data-testid="deadline-date-input"
+            className="w-full bg-transparent px-3 py-3 text-dark-100 placeholder:text-dark-600 focus:outline-none [color-scheme:dark]"
+          />
+        )}
       </div>
 
       <div className="flex items-center justify-between gap-3 text-sm">

--- a/lib/platform/is-ios.test.ts
+++ b/lib/platform/is-ios.test.ts
@@ -1,0 +1,31 @@
+import { assert, test } from "vitest";
+import { isIOSUserAgent } from "./is-ios.ts";
+
+test("isIOSUserAgent detects iPhone", () => {
+  assert.equal(
+    isIOSUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+    ),
+    true
+  );
+});
+
+test("isIOSUserAgent detects iPadOS desktop UA", () => {
+  assert.equal(
+    isIOSUserAgent(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+      "MacIntel",
+      5
+    ),
+    true
+  );
+});
+
+test("isIOSUserAgent rejects Android", () => {
+  assert.equal(
+    isIOSUserAgent(
+      "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36"
+    ),
+    false
+  );
+});

--- a/lib/platform/is-ios.ts
+++ b/lib/platform/is-ios.ts
@@ -1,0 +1,12 @@
+/**
+ * Detects iOS (iPhone, iPod, iPad including iPadOS desktop UA).
+ */
+export function isIOSUserAgent(userAgent: string, platform?: string, maxTouchPoints?: number): boolean {
+  if (/iPad|iPhone|iPod/.test(userAgent)) return true;
+  return platform === "MacIntel" && (maxTouchPoints ?? 0) > 1;
+}
+
+export function detectIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return isIOSUserAgent(navigator.userAgent, navigator.platform, navigator.maxTouchPoints);
+}


### PR DESCRIPTION
## Summary

Implements three mobile UX improvements for PayEasy escrows and sharing:

- **#750 — iOS-friendly deadline picker:** Detects iOS via user agent and opens a bottom-sheet date picker (month/day/year) instead of the native inline `type="date"` control. Non-iOS platforms are unchanged.
- **#748 — Swipe gestures on escrow cards:** Adds `SwipeableEscrowCard` with framer-motion horizontal drag. Swiping left ≥80px reveals Archive and Share; swiping ≥200px archives directly when the escrow is archivable. Integrated on the escrows list for landlord and roommate cards.
- **#749 — Native share for payment links:** When `navigator.share` is available, `ShareEscrowModal` uses a primary **Share** button (native share sheet). Falls back to **Copy Link** when Web Share is unavailable.

Also **fixes a corrupted `app/escrows/page.tsx`** on `main` (broken merge with duplicate imports and invalid JSX) by restoring a single coherent page: dark theme, landlord/roommate tabs, archived toggle, and swipe/share integration.

## Changes

| File | Change |
|------|--------|
| `components/ui/date-input.tsx` | iOS bottom-sheet picker; native input elsewhere |
| `lib/platform/is-ios.ts` | iOS UA detection helper |
| `lib/platform/is-ios.test.ts` | Unit tests for UA detection |
| `components/escrow/SwipeableEscrowCard.tsx` | **New** swipe-to-reveal actions |
| `app/escrows/page.tsx` | Swipe wrappers, share modal, merge fix |
| `components/escrow/ShareEscrowModal.tsx` | Share-first when `navigator.share` exists |

## Test plan

- [ ] **iOS Safari (or simulator):** Open Create Escrow → tap deadline → bottom sheet with month/day/year appears; confirm selects a valid date ≥ tomorrow.
- [ ] **Desktop Chrome:** Deadline still uses native date input.
- [ ] **Mobile / narrow viewport:** On `/escrows`, swipe a landlord card left ~80px → Archive + Share visible; tap Share → modal opens; tap Archive → escrow archived.
- [ ] **Mobile:** Swipe a released/expired landlord card left ≥200px → archives without tapping the button.
- [ ] **Android Chrome:** Open share modal on escrow dashboard → **Share** opens system share sheet with correct URL.
- [ ] **Desktop without Web Share:** Share modal shows **Copy Link** and copies to clipboard.
- [ ] Run `npm test` — includes `lib/platform/is-ios.test.ts`.
- [ ] Run `npm run lint` and `npm run build`.

## Issues

Closes #750
Closes #748
Closes #749